### PR TITLE
Feat: Add IsVisible property and ClosePanel method #48

### DIFF
--- a/Src/Innovative.Blazor.Components/Services/InnovativeDialogService.cs
+++ b/Src/Innovative.Blazor.Components/Services/InnovativeDialogService.cs
@@ -9,6 +9,11 @@ namespace Innovative.Blazor.Components.Services;
 public interface IInnovativeSidePanelService
 {
     /// <summary>
+    /// Returns true if the side panel is visible, otherwise false.
+    /// </summary>
+    bool IsVisible { get; }
+
+    /// <summary>
     /// Opens a side panel dialog with the specified model in display mode.
     /// </summary>
     Task OpenInDisplayMode<T>(T model, bool showEdit = true, bool showClose = true, bool showDelete = false) where T : class;
@@ -17,6 +22,11 @@ public interface IInnovativeSidePanelService
     /// Opens a side panel dialog with the specified model in edit mode as a new instance of <code>T</code> is created.
     /// </summary>
     Task OpenInEditMode<T>(T model, bool showClose = true, bool showDelete = false) where T : class;
+
+    /// <summary>
+    /// Closes the side panel dialog if it is open.
+    /// </summary>
+    void ClosePanel<T>(T model) where T : class;
 }
 
 internal sealed class InnovativeSidePanelService
@@ -25,6 +35,7 @@ internal sealed class InnovativeSidePanelService
     IInnovativeStringLocalizerFactory localizerFactory
 ) : IInnovativeSidePanelService
 {
+    public bool IsVisible => sidePanelService.IsVisible;
 
     public async Task OpenInEditMode<T>(T model, bool showClose = true, bool showDelete = false) where T : class
     {
@@ -83,7 +94,6 @@ internal sealed class InnovativeSidePanelService
         await sidePanelService
               .OpenSidepanelAsync<SidePanelComponent<T>>(parameters, options)
               .ConfigureAwait(false);
-
     }
 
     private string GetFormTitle<T>() where T : class
@@ -113,5 +123,13 @@ internal sealed class InnovativeSidePanelService
             _ => "30vw"
         };
         return size;
+    }
+
+    public void ClosePanel<T>(T model) where T : class
+    {
+        if (IsVisible)
+        {
+            sidePanelService.CloseSidepanel(model);
+        }
     }
 }

--- a/Tests/Innovative.Blazor.Components.Tests/Services/InnovativeSidePanelServiceTests.cs
+++ b/Tests/Innovative.Blazor.Components.Tests/Services/InnovativeSidePanelServiceTests.cs
@@ -1,0 +1,58 @@
+using System;
+using Innovative.Blazor.Components.Localizer;
+using Innovative.Blazor.Components.Services;
+using Moq;
+
+namespace Innovative.Blazor.Components.Tests.Services;
+
+public class InnovativeSidePanelServiceTests
+{
+    private readonly Mock<ISidepanelService> sidePanelServiceMock;
+
+    private readonly InnovativeSidePanelService subject;
+
+    public InnovativeSidePanelServiceTests()
+    {
+        sidePanelServiceMock = new Mock<ISidepanelService>();
+
+        var localizer = new Mock<IInnovativeStringLocalizer>();
+        var localizerFactory = new Mock<IInnovativeStringLocalizerFactory>();
+
+        localizerFactory
+            .Setup(f => f.Create(It.IsAny<Type>()))
+            .Returns(localizer.Object);
+
+        subject = new InnovativeSidePanelService(sidePanelServiceMock.Object, localizerFactory.Object);
+    }
+
+    [Fact]
+    public void WhenClosePanel_WhileOpen_ItShouldCloseTheSidePanel()
+    {
+        // Arrange
+        sidePanelServiceMock
+            .Setup(expression: x => x.IsVisible)
+            .Returns(value: true);
+
+        // Act
+        subject.ClosePanel(model: new TestFormModel());
+
+        // Assert
+        sidePanelServiceMock.Verify(expression: x => x.CloseSidepanel(It.IsAny<TestFormModel>()), times: Times.Once);
+    }
+
+    [Fact]
+    public void WhenClosePanel_WhileClosed_ItShouldDoNothing()
+    {
+        // Arrange
+        sidePanelServiceMock
+            .Setup(expression: x => x.IsVisible)
+            .Returns(value: false);
+
+        // Act
+        subject.ClosePanel(new TestFormModel());
+
+        // Assert
+        sidePanelServiceMock.Verify(x => x.CloseSidepanel(It.IsAny<TestFormModel>()), Times.Never);
+    }
+
+}


### PR DESCRIPTION
Feat: Add IsVisible property and ClosePanel method #48

Updated IInnovativeSidePanelService to include a new
IsVisible property and a ClosePanel<T>(T model) method
for managing the side panel's visibility. Implemented
these changes in the InnovativeSidePanelService class.
Added unit tests in InnovativeSidePanelServiceTests.cs
to verify the functionality of the ClosePanel method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to check if the side panel is visible.
  - Introduced a method to close the side panel with a provided model.

- **Tests**
  - Added tests to verify the correct behavior of closing the side panel based on its visibility state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->