### PR TITLE
Fix typo in CSS variable and update default side panel color

### DIFF
--- a/ExampleApp/wwwroot/css/app.css
+++ b/ExampleApp/wwwroot/css/app.css
@@ -113,5 +113,5 @@ code {
     text-align: start;
 }
 :root {
-    --nnovative-sidepanel-background-color: #fff;
+    --innovative-sidepanel-background-color: blue;
 }

--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelHost.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelHost.razor.css
@@ -14,7 +14,7 @@
 
 .sidepanel-container {
     z-index: 1001;
-    background: var(--nnovative-sidepanel-background-color);
+    background: var(--innovative-sidepanel-background-color);
     height: 100vh;
     box-shadow: -2px 0 8px rgba(0,0,0,0.1);
     position: relative;

--- a/Src/Innovative.Blazor.Components/base.css
+++ b/Src/Innovative.Blazor.Components/base.css
@@ -1,3 +1,3 @@
 :root {
-    --nnovative-sidepanel-background-color: #fff;
+    --innovative-sidepanel-background-color: #fff;
 }


### PR DESCRIPTION
Corrected the CSS variable name from `--nnovative-sidepanel-background-color` to `--innovative-sidepanel-background-color`. Updated the side panel default background color to blue in the example app styles.