### PR TITLE
#64 Fix a failing unit test `When_OnParametersSet_ItShouldInitializeFormValues`

### DIFF
--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.cs
@@ -36,11 +36,19 @@ public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelServi
     public void OpenCustomDialog()
     {
         isCustomDialog = true;
+        if (ViewChildContent == null && EditChildContent == null)
+        {
+            return;
+        }
         StateHasChanged();
     }
     public void CloseCustomDialog()
     {
         isCustomDialog = false;
+        if (ViewChildContent == null && EditChildContent == null)
+        {
+            return;
+        }
         StateHasChanged();
     }
 

--- a/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
+++ b/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
@@ -75,7 +75,8 @@ public class InnovativeFormTests : LocalizedTestBase
         component.SetFormValue(nameof(model.DateProperty), testDate);
 
         // Act
-        await component.OnFormSubmit();
+        await component.OnFormSubmit()
+                       .ConfigureAwait(true);
 
         // Assert
         Assert.Equal("Updated", model.StringProperty);
@@ -118,7 +119,8 @@ public class InnovativeFormTests : LocalizedTestBase
         component.SetFormValue(nameof(actual.DateProperty), testDate);
 
         // Act
-        await component.OnFormReset();
+        await component.OnFormReset()
+                       .ConfigureAwait(true);
 
         // Assert
         Assert.Equal(expected.StringProperty, actual.StringProperty);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dialog behavior to prevent unnecessary updates when no content is available to display.

- **Tests**
  - Enhanced test reliability for form submission and reset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->