### PR TITLE
Task 110: maak het reageren op property wijzigingen mogelijk in side panel

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <!-- UI Components -->
-    <PackageVersion Include="Radzen.Blazor" Version="7.1.2" />
+    <PackageVersion Include="Radzen.Blazor" Version="7.1.3" />
   </ItemGroup>
 </Project>

--- a/ExampleApp/Components/FullNamePreviewComponent.razor
+++ b/ExampleApp/Components/FullNamePreviewComponent.razor
@@ -1,0 +1,2 @@
+@inherits Innovative.Blazor.Components.Components.CustomComponent<ExampleApp.Pages.PersonPreviewModel>
+<span>Full name:  @Value?.FirstName @Value?.LastName</span>

--- a/ExampleApp/Components/FullNamePreviewComponent.razor.cs
+++ b/ExampleApp/Components/FullNamePreviewComponent.razor.cs
@@ -1,0 +1,36 @@
+using ExampleApp.Pages;
+using Innovative.Blazor.Components.Components;
+
+namespace ExampleApp.Components;
+
+public partial class FullNamePreviewComponent : CustomComponent<PersonPreviewModel>
+{
+    public new PersonPreviewModel? Value
+    {
+        get => base.Value;
+        set
+        {
+            if (base.Value != value)
+            {
+                base.Value = value;
+                ValueChanged.InvokeAsync(arg: value);
+                StateHasChanged();
+            }
+        }
+    }
+
+    public override void OnFormValueChanged(KeyValuePair<string, object?> pair)
+    {
+        if (Value != null)
+        {
+            if (pair is {Key: nameof(PersonPreviewModel.FirstName), Value: string firstName})
+            {
+                Value.FirstName = firstName;
+            }
+            if (pair is {Key: nameof(PersonPreviewModel.LastName), Value: string lastName})
+            {
+                Value.LastName = lastName;
+            }
+        }
+    }
+}

--- a/ExampleApp/Components/FullNamePreviewComponent.razor.cs
+++ b/ExampleApp/Components/FullNamePreviewComponent.razor.cs
@@ -18,19 +18,4 @@ public partial class FullNamePreviewComponent : CustomComponent<PersonPreviewMod
             }
         }
     }
-
-    public override void OnFormValueChanged(KeyValuePair<string, object?> pair)
-    {
-        if (Value != null)
-        {
-            if (pair is {Key: nameof(PersonPreviewModel.FirstName), Value: string firstName})
-            {
-                Value.FirstName = firstName;
-            }
-            if (pair is {Key: nameof(PersonPreviewModel.LastName), Value: string lastName})
-            {
-                Value.LastName = lastName;
-            }
-        }
-    }
 }

--- a/ExampleApp/Layout/NavMenu.razor
+++ b/ExampleApp/Layout/NavMenu.razor
@@ -45,6 +45,16 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="grid/complex/3">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Complex Grid 3
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="grid/complex/4">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Complex Grid 4
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="displayview">
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Display View
             </NavLink>

--- a/ExampleApp/Pages/ExampleGridWithPreview.razor
+++ b/ExampleApp/Pages/ExampleGridWithPreview.razor
@@ -1,0 +1,11 @@
+@page "/grid/complex/4"
+@using Innovative.Blazor.Components.Components
+
+<h3> Grid Example 4</h3>
+<p>Shows a grid with a preview control in the side panel.</p>
+
+<InnovativeGrid TItem="PersonPreviewGridModel"
+                MinHeightOption="GridHeight.Max"
+                Data="@items"
+                EnableRowSelection="true"
+                OnSelectionChanged="OnRowSelected" />

--- a/ExampleApp/Pages/ExampleGridWithPreview.razor.cs
+++ b/ExampleApp/Pages/ExampleGridWithPreview.razor.cs
@@ -1,0 +1,128 @@
+using System.Security.Cryptography;
+using ExampleApp.Components;
+using Innovative.Blazor.Components.Components;
+using Innovative.Blazor.Components.Services;
+
+namespace ExampleApp.Pages;
+
+public partial class ExampleGridWithPreview(IInnovativeSidePanelService sidePanelService)
+{
+    private readonly string[] firstNames = ["Jan", "Jaap", "Piet", "Kees", "Tom"];
+
+    private readonly string[] lastNames = ["Appelboom", "Perenboom", "Kersenboom", "Kerstboom"];
+
+    private readonly List<PersonPreviewGridModel> items = [];
+
+    protected override void OnInitialized()
+    {
+        var data = Enumerable.Range(start: 1, count: 10)
+                             .Select(selector: i => new PersonPreviewModel
+                                                    {
+                                                        Id = Guid.NewGuid(),
+                                                        FirstName = firstNames[RandomNumberGenerator.GetInt32(toExclusive: firstNames.Length)],
+                                                        LastName = lastNames[RandomNumberGenerator.GetInt32(toExclusive: lastNames.Length)]
+                                                    })
+                             .ToList();
+
+        items.AddRange(collection: data.Select(selector: PersonPreviewGridModel.ToGridModel));
+    }
+
+    private async Task OnRowSelected(IEnumerable<PersonPreviewGridModel> obj)
+    {
+        PersonPreviewGridModel? rowItem = obj.FirstOrDefault();
+        if (rowItem != null)
+        {
+            var model = PersonPreviewFormModel.ToFormModel(instance: PersonPreviewGridModel.ToModel(instance: rowItem));
+            model.SaveFormAction = () =>
+                                   {
+                                       var item = items.Single(x => x.Id == model.Id);
+                                       item.FirstName = model.FirstName;
+                                       item.LastName = model.LastName;
+                                       return Task.CompletedTask;
+                                   };
+
+            await sidePanelService
+                  .OpenInEditMode(model: model)
+                  .ConfigureAwait(continueOnCapturedContext: true);
+        }
+    }
+}
+
+public record PersonPreviewModel
+{
+    public Guid Id { get; set; }
+
+    public string? FirstName { get; set; }
+
+    public string? LastName { get; set; }
+
+    public override string ToString() => $"{FirstName} {LastName}";
+}
+
+[UIGridClass(AllowSorting = true)]
+public sealed class PersonPreviewGridModel
+{
+    public Guid Id { get; set; }
+
+    [UIGridField(Name = "Voornaam")]
+    public string? FirstName { get; set; }
+
+    [UIGridField(Name = "Achternaam")]
+    public string? LastName { get; set; }
+
+    public static PersonPreviewGridModel ToGridModel(PersonPreviewModel instance)
+    {
+        return new PersonPreviewGridModel
+               {
+                   Id = instance?.Id ?? Guid.NewGuid(),
+                   FirstName = instance?.FirstName,
+                   LastName = instance?.LastName
+               };
+    }
+    public static PersonPreviewModel ToModel(PersonPreviewGridModel instance)
+    {
+        return new PersonPreviewModel
+               {
+                   Id = instance?.Id ?? Guid.NewGuid(),
+                   FirstName = instance?.FirstName,
+                   LastName = instance?.LastName
+               };
+    }
+}
+
+public sealed class PersonPreviewFormModel : FormModel
+{
+    private const string ColumnGroup1 = "PropertyColumn1";
+
+    public PersonPreviewFormModel()
+    {
+        AddViewColumn(
+                      name: ColumnGroup1,
+                      width: 1,
+                      order: 1,
+                      offset: 0
+                     );
+
+    }
+    public Guid Id { get; set; }
+
+    [UIFormField(name: "Voornaam", ShouldNotifyChanges = true, ColumnGroup = ColumnGroup1)]
+    public string? FirstName { get; init; }
+
+    [UIFormField(name: "Achternaam", ShouldNotifyChanges = true, ColumnGroup = ColumnGroup1)]
+    public string? LastName { get; init; }
+
+    [UIFormField(name: "Naam", FormComponent = typeof(FullNamePreviewComponent), ColumnGroup = ColumnGroup1)]
+    public PersonPreviewModel? FullName { get; init; }
+
+    public static PersonPreviewFormModel ToFormModel(PersonPreviewModel instance)
+    {
+        return new PersonPreviewFormModel
+               {
+                   Id = instance?.Id ?? Guid.NewGuid(),
+                   FirstName = instance?.FirstName,
+                   LastName = instance?.LastName,
+                   FullName = instance
+               };
+    }
+}

--- a/ExampleApp/Pages/ExampleGridWithPreview.razor.cs
+++ b/ExampleApp/Pages/ExampleGridWithPreview.razor.cs
@@ -48,7 +48,7 @@ public partial class ExampleGridWithPreview(IInnovativeSidePanelService sidePane
     }
 }
 
-public record PersonPreviewModel
+public record PersonPreviewModel: INotifyFormValueChanged
 {
     public Guid Id { get; set; }
 
@@ -57,6 +57,19 @@ public record PersonPreviewModel
     public string? LastName { get; set; }
 
     public override string ToString() => $"{FirstName} {LastName}";
+
+    public void OnFormValueChanged(string propertyName, object? value)
+    {
+        switch (propertyName)
+        {
+            case nameof(FirstName):
+                FirstName = value?.ToString();
+                break;
+            case nameof(LastName):
+                LastName = value?.ToString();
+                break;
+        }
+    }
 }
 
 [UIGridClass(AllowSorting = true)]

--- a/Src/Innovative.Blazor.Components/Components/Form/CustomComponent.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/CustomComponent.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Innovative.Blazor.Components.Components;
 
-public abstract class CustomComponent<T>: ComponentBase
+public abstract class CustomComponent<T> : ComponentBase
 {
     [Parameter]
     public T? Value { get; set; }
@@ -13,5 +13,7 @@ public abstract class CustomComponent<T>: ComponentBase
     [Parameter]
     public EventCallback ValueChanged { get; set; }
 
-    protected void OnValueChanged() => ValueChanged.InvokeAsync(Value);
+    protected void OnValueChanged() => ValueChanged.InvokeAsync(arg: Value);
+
+    public virtual void OnFormValueChanged(KeyValuePair<string, object?> pair) { }
 }

--- a/Src/Innovative.Blazor.Components/Components/Form/CustomComponent.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/CustomComponent.cs
@@ -14,6 +14,4 @@ public abstract class CustomComponent<T> : ComponentBase
     public EventCallback ValueChanged { get; set; }
 
     protected void OnValueChanged() => ValueChanged.InvokeAsync(arg: Value);
-
-    public virtual void OnFormValueChanged(KeyValuePair<string, object?> pair) { }
 }

--- a/Src/Innovative.Blazor.Components/Components/Form/INotifyFormValueChanged.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/INotifyFormValueChanged.cs
@@ -1,0 +1,6 @@
+namespace Innovative.Blazor.Components.Components;
+
+public interface INotifyFormValueChanged
+{
+    void OnFormValueChanged(string propertyName, object? value);
+}

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor
@@ -6,7 +6,7 @@
     <section class="rz-dialog-side-content-layout">
         @{
             var model = Model as FormModel;
-            System.Diagnostics.Debug.Assert(model != null, nameof(model) + " != null");
+            System.Diagnostics.Debug.Assert(model != null, $"{nameof(model)} is null!");
             foreach (var exception in model.Exceptions)
             {
                 <section class="rz-alert rz-background-color-danger-lighter gap-2 column-span-4">

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
@@ -314,12 +314,20 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
 
     private void NotifyChange(string propertyName, object? value)
     {
-        var type = Model?.GetType();
-         
-        if (type is not null && type.IsGenericType && type.GetGenericTypeDefinition() == typeof(CustomComponent<>))
+        var props = Model?.GetType().GetProperties() ?? [];
+        foreach (PropertyInfo prop in props)
         {
-            var instance = Model as CustomComponent<TModel>;
-            instance?.OnFormValueChanged(pair: new KeyValuePair<string, object?>(key: propertyName, value: value));
+            var attr = prop?.GetCustomAttribute(typeof(UIFormField));
+
+            if(attr is UIFormField {ShouldNotifyChanges: true } comp && UIFormField.InheritsFromGenericCustomComponent(comp.FormComponent))
+            {
+                /*
+                    // Do some magic to get the instance of CustomComponent<TypeOfProperty>
+                    var instance = prop as CustomComponent<TypeOfProperty>;
+                    // And then invoke OnFormValueChanged
+                    instance?.OnFormValueChanged(pair: new KeyValuePair<string, object?>(key: propertyName, value: value));
+                */
+            }
         }
     }
 

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -103,8 +102,23 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
 
     public Task OnFormReset()
     {
+        ResetToOriginalValues();
         ParentDialog?.CloseCustomDialog();
         return Task.CompletedTask;
+    }
+
+    private void ResetToOriginalValues()
+    {
+        foreach (var property in GetPropertiesWithUiFormField())
+        {
+            var fieldAttribute = property.GetCustomAttribute<UIFormField>();
+            bool notifyChanges = fieldAttribute?.ShouldNotifyChanges ?? false;
+
+            if (notifyChanges)
+            {
+                NotifyPropertyChanged(property.Name, property.GetValue(obj: Model));
+            }
+        }
     }
 
     protected string GetColumnWidthClass(string columnGroup)
@@ -216,7 +230,6 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
         {
             try
             {
-
                 if (attribute.FormComponent != null)
                 {
                     // Add label for component
@@ -307,26 +320,21 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
         formValues[key: propertyName] = value;
         if (shouldNotifyChange)
         {
-            Console.WriteLine($"Setting value for {propertyName} to {value}");
-            NotifyChange(propertyName: propertyName, value: value);
+            NotifyPropertyChanged(propertyName: propertyName, value: value);
         }
     }
 
-    private void NotifyChange(string propertyName, object? value)
+    private void NotifyPropertyChanged(string propertyName, object? value)
     {
-        var props = Model?.GetType().GetProperties() ?? [];
-        foreach (PropertyInfo prop in props)
+        var properties = Model?.GetType().GetProperties() ?? [];
+        foreach (PropertyInfo info in properties)
         {
-            var attr = prop?.GetCustomAttribute(typeof(UIFormField));
+            var modelProperty = info?.GetValue(Model);
 
-            if(attr is UIFormField {ShouldNotifyChanges: true } comp && UIFormField.InheritsFromGenericCustomComponent(comp.FormComponent))
+            if (modelProperty is INotifyFormValueChanged complexType)
             {
-                /*
-                    // Do some magic to get the instance of CustomComponent<TypeOfProperty>
-                    var instance = prop as CustomComponent<TypeOfProperty>;
-                    // And then invoke OnFormValueChanged
-                    instance?.OnFormValueChanged(pair: new KeyValuePair<string, object?>(key: propertyName, value: value));
-                */
+                complexType.OnFormValueChanged(propertyName, value);
+                return;
             }
         }
     }

--- a/Src/Innovative.Blazor.Components/Components/Form/UIFormField.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/UIFormField.cs
@@ -9,7 +9,7 @@ public sealed class UIFormField(string name) : UIField(name)
 {
     public string? ColumnGroup { get; set; }
     public bool UseWysiwyg { get; set; }
-    private static bool InheritsFromGenericCustomComponent(Type? type)
+    internal static bool InheritsFromGenericCustomComponent(Type? type)
     {
         while (type != null && type != typeof(object))
         {

--- a/Src/Innovative.Blazor.Components/Components/Form/UIFormField.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/UIFormField.cs
@@ -49,4 +49,5 @@ public sealed class UIFormField(string name) : UIField(name)
     public string[]? FormParameters { get; set; }
     public string? TextProperty { get; set; }
     public string DataTestId { get; set; } = string.Empty;
+    public bool ShouldNotifyChanges { get; set; }
 }

--- a/Src/Innovative.Blazor.Components/Components/Form/UIFormField.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/UIFormField.cs
@@ -9,6 +9,7 @@ public sealed class UIFormField(string name) : UIField(name)
 {
     public string? ColumnGroup { get; set; }
     public bool UseWysiwyg { get; set; }
+
     internal static bool InheritsFromGenericCustomComponent(Type? type)
     {
         while (type != null && type != typeof(object))
@@ -19,6 +20,7 @@ public sealed class UIFormField(string name) : UIField(name)
         }
         return false;
     }
+
     private Type? _displayComponent;
     public Type? DisplayComponent
     {
@@ -32,7 +34,7 @@ public sealed class UIFormField(string name) : UIField(name)
             _displayComponent = value;
         }
     }
-    public string[]? DisplayParameters { get; set; }
+
     private Type? _formComponent;
     public Type? FormComponent
     {
@@ -46,6 +48,8 @@ public sealed class UIFormField(string name) : UIField(name)
             _formComponent = value;
         }
     }
+
+    public string[]? DisplayParameters { get; set; }
     public string[]? FormParameters { get; set; }
     public string? TextProperty { get; set; }
     public string DataTestId { get; set; } = string.Empty;

--- a/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
+++ b/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
@@ -233,11 +233,11 @@ public static class DynamicFormViewTestExtensions
         return formValues?.TryGetValue(propertyName, out var value) == true ? value : null;
     }
 
-    public static void SetFormValue<T>(this InnovativeForm<T> component, string propertyName, object value)
+    public static void SetFormValue<T>(this InnovativeForm<T> component, string propertyName, object value, bool shouldNotifyChange = false)
     {
         var setValueMethod = typeof(InnovativeForm<T>).GetMethod("SetValue",
                                                                             BindingFlags.NonPublic | BindingFlags.Instance);
-        setValueMethod?.Invoke(component, new[] { propertyName, value });
+        setValueMethod?.Invoke(component, new[] { propertyName, value, shouldNotifyChange });
     }
 
     public static IReadOnlyCollection<PropertyInfo>? GetUngroupedProperties<T>(this InnovativeForm<T> component)


### PR DESCRIPTION
Apply `INotifyFormValueChanged` on a complex type that is used as a FormComponent property in a model.
See ExampleGrid 4 for an implementation of this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new grid page with a preview side panel accessible via the navigation menu.
  * Added a custom full name preview component for person entries.
  * Implemented a mechanism to notify components of form value changes for enhanced interactivity.

* **Bug Fixes**
  * Improved assertion messages for clearer debugging.

* **Chores**
  * Removed an obsolete comment line from the package version management file.

* **Tests**
  * Enhanced test utilities to support change notification in form value setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->