### PR TITLE
130 Side panel icoon verbeteren

### DIFF
--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor
@@ -9,7 +9,7 @@
             {
             <button class="sidepanel-icon-button" id="sidePanelCloseButton"
                     @onclick="@sidePanelService.CloseSidepanel">
-                <span class="material-symbols-outlined">keyboard_tab</span>
+                <span class="material-symbols-outlined">right_panel_close</span>
             </button>
             }
             <h3>@Title</h3>


### PR DESCRIPTION
De icoon is ongeveer hetzelfde  als de start icoon van de Toegangscontrole pagina in Automate.

### Toegangscontrole
<img width="178" height="176" alt="Image" src="https://github.com/user-attachments/assets/5ff4e9e3-9dba-4e2e-ba36-1010692eb8e2" />

### Side panel
<img width="64" height="68" alt="Image" src="https://github.com/user-attachments/assets/72e3126a-8ef3-434b-a892-bb528c6099fd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the close button icon in the side panel header for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->