### PR TITLE
145 - Icoon font-sizes kloppen niet in side panel

### DIFF
--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.css
@@ -52,10 +52,15 @@
 
 .sidepanel-icon-button .material-symbols-outlined {
     color: var(--rz-text-tertiary-color);
+    font-size: 1.25rem;
 }
 
-.sidepanel-icon-button:hover  .material-symbols-outlined {
+.sidepanel-icon-button:hover .material-symbols-outlined {
     color: var(--rz-text-title-color);
+}
+
+.material-symbols-outlined {
+    font-family: 'Material Symbols', sans-serif;
 }
 
 .sidepanel-content {
@@ -69,8 +74,4 @@
     padding: 1rem;
     display: flex;
     gap: 10px;
-}
-
-.material-symbols-outlined {
-    font-family: 'Material Symbols', sans-serif;
 }


### PR DESCRIPTION
Verbeterde weergave van pictogrammen in het zijpaneel door het bijwerken van de lettergrootte en het opnieuw indelen van stijlregels voor pictogrammen voor betere consistentie.
