### PR TITLE
Docs: updated an example to show the correct working of DisplayLabel …

### DIFF
--- a/ExampleApp/Components/ComplexComponent.razor
+++ b/ExampleApp/Components/ComplexComponent.razor
@@ -1,4 +1,0 @@
-@inherits Innovative.Blazor.Components.Components.CustomComponent<ComplexModel>
-
-<RadzenDropDown TItem="ComplexModel" @bind-Value="Value" TextProperty="Name" Data="Items">
-</RadzenDropDown>

--- a/ExampleApp/Components/ComplexDisplayComponent.razor
+++ b/ExampleApp/Components/ComplexDisplayComponent.razor
@@ -1,0 +1,7 @@
+@inherits Innovative.Blazor.Components.Components.CustomComponent<ComplexModel>
+
+<h1>CoMpLeX cOmPoNeNt (this is my own title/label)</h1>
+<ul>
+    <li>Name: @Value?.Name</li>
+    <li>@Value?.Description</li>
+</ul>

--- a/ExampleApp/Components/ComplexDisplayComponent.razor.cs
+++ b/ExampleApp/Components/ComplexDisplayComponent.razor.cs
@@ -1,0 +1,13 @@
+using Innovative.Blazor.Components.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace ExampleApp.Components;
+
+public partial class ComplexDisplayComponent : CustomComponent<ComplexModel>
+{
+    // This parameter is used to control the display of the label in the component.
+    // The only requirements are: it must be a parameter and its name must be "DisplayLabel".
+    // The property type should be as open as possible, so "object?" will do the job.
+    [Parameter]
+    public object? DisplayLabel { get; set; }
+}

--- a/ExampleApp/Components/ComplexEditComponent.razor
+++ b/ExampleApp/Components/ComplexEditComponent.razor
@@ -1,0 +1,4 @@
+@inherits Innovative.Blazor.Components.Components.CustomComponent<ComplexModel>
+
+<h1>CoMpLeX cOmPoNeNt (this is my own title/label)</h1>
+<RadzenDropDown TItem="ComplexModel" @bind-Value="Value" TextProperty="Name" Data="_items" />

--- a/ExampleApp/Components/ComplexEditComponent.razor.cs
+++ b/ExampleApp/Components/ComplexEditComponent.razor.cs
@@ -3,14 +3,15 @@ using Microsoft.AspNetCore.Components;
 
 namespace ExampleApp.Components;
 
-public partial class ComplexComponent : CustomComponent<ComplexModel>
+public partial class ComplexEditComponent : CustomComponent<ComplexModel>
 {
-    private List<ComplexModel> Items  = new List<ComplexModel>();
+    private List<ComplexModel> _items  = [];
+    
     protected override async Task OnInitializedAsync()
     {
         // Simulate an asynchronous data fetch
         await Task.Delay(1000).ConfigureAwait(false);
-        Items =
+        _items =
         [
             new ComplexModel
             {
@@ -29,5 +30,10 @@ public partial class ComplexComponent : CustomComponent<ComplexModel>
             }
         ];
     }
-}
 
+    // This parameter is used to control the display of the label in the component.
+    // The only requirements are: it must be a parameter and its name must be "DisplayLabel".
+    // The property type should be as open as possible, so "object?" will do the job.
+    [Parameter]
+    public object? DisplayLabel { get; set; }
+}

--- a/ExampleApp/Pages/ExampleDialogService2.razor.cs
+++ b/ExampleApp/Pages/ExampleDialogService2.razor.cs
@@ -140,8 +140,14 @@ public class PersonModel : FormModel
     [UIFormField(name : "Description", UseWysiwyg = true, ColumnGroup = "Description")]
     public string? Description { get; set; }
 
-    [UIFormField(name: "Complex Component", ColumnGroup = "Description", FormComponent = typeof(ComplexComponent),
-                 TextProperty = nameof(ComplexComponent.Description))]
+    [UIFormField(name: "Complex Component",
+                 ColumnGroup = "Description",
+                 FormComponent = typeof(ComplexEditComponent),
+                 FormParameters = ["DisplayLabel=false"], // There must be a parameter named DisplayLabel in the ComplexEditComponent
+                 DisplayComponent = typeof(ComplexDisplayComponent),
+                 DisplayParameters = ["DisplayLabel=false"], // There must be a parameter named DisplayLabel in the ComplexDisplayComponent
+                 TextProperty = nameof(ComplexComponent.Description)
+    )]
     public ComplexModel? ComplexComponent { get; set; } = new()
     {
         Name = "Complex Component",


### PR DESCRIPTION
Updated an example to show the correct working of DisplayLabel.

See: #160

# How to hide the label of a Custom Component in SharedBlazorComponents

In order to control the visibility of a label of a Custom Component in SharedBlazorComponents, you must do two things:

1. Add a parameter property, named `DisplayLabel`, of type `object?` to the custom componenent.
``` csharp
    [Parameter]
    public object? DisplayLabel { get; set; }
```
2. Add "DisplayLabel=false" to the `FormParameters` and/or `DisplayParameters`
``` csharp
    [UIFormField(name: "My Custom Component",
                 FormComponent = typeof(MyComplexTypeEditComponent),       // This is a CustomComponent<MyComplexType>
                 FormParameters = ["DisplayLabel=false"],                  // There must be a parameter named DisplayLabel in the MyComplexTypeEditComponent
                 DisplayComponent = typeof(MyComplexTypeDisplayComponent), // This is a CustomComponent<MyComplexType>
                 DisplayParameters = ["DisplayLabel=false"],               // There must be a parameter named DisplayLabel in the MyComplexTypeDisplayComponent
    )]
    public MyComplexType? MyType { get; set; }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a read-only view to display complex item details with a clear heading.
  - Forms now use separate edit and display views for improved clarity.
  - Added an option to show or hide the label on these views.

- Refactor
  - Renamed the complex editor for consistency and updated forms to use it.
  - Minor UI polish: added a header and simplified the dropdown control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->