### PR TITLE
Bug #66: Fix re-render custom actions on reopen side panel

### DIFF
--- a/ExampleApp/Components/PasswordCheckComponent.razor.cs
+++ b/ExampleApp/Components/PasswordCheckComponent.razor.cs
@@ -8,7 +8,7 @@ public partial class PasswordCheckComponent : ComponentBase, IFormComponent
 {
     [Parameter] public object? Model { get; set; }
 
-    [Parameter] public SidePanelComponent<PersonModel>? ParentDialog { get; set; }
+    [Parameter] public SidePanelComponent<PersonFormModel>? ParentDialog { get; set; }
 
     // if a parameter with name "ActionProperty" does not exist
     // the component crashes on render
@@ -26,7 +26,7 @@ public partial class PasswordCheckComponent : ComponentBase, IFormComponent
 
     public Task OnFormSubmit()
     {
-        if (ParentDialog is not null && Model is PersonModel person)
+        if (ParentDialog is not null && Model is PersonFormModel person)
         {
             var result = !string.IsNullOrEmpty(password) &&
                             password.Any(x=> char.IsDigit(x)) &&

--- a/ExampleApp/Components/PasswordUpdateComponent.razor.cs
+++ b/ExampleApp/Components/PasswordUpdateComponent.razor.cs
@@ -10,7 +10,7 @@ public partial class PasswordUpdateComponent : ComponentBase, IFormComponent
 
     [Parameter] public object? Model { get; set; }
 
-    [Parameter] public SidePanelComponent<PersonModel>? ParentDialog { get; set; }
+    [Parameter] public SidePanelComponent<PersonFormModel>? ParentDialog { get; set; }
 
     // if a parameter with name "ActionProperty" does not exist
     // the component crashes on render
@@ -26,7 +26,7 @@ public partial class PasswordUpdateComponent : ComponentBase, IFormComponent
 
     public Task OnFormSubmit()
     {
-        if (ParentDialog is not null && Model is PersonModel person)
+        if (ParentDialog is not null && Model is PersonFormModel person)
         {
             person.UpdatePasswordAction!.Invoke(obj: ++counter);
         }

--- a/ExampleApp/Pages/ExampleDialogService2.razor.cs
+++ b/ExampleApp/Pages/ExampleDialogService2.razor.cs
@@ -9,68 +9,63 @@ namespace ExampleApp.Pages;
 
 public partial class ExampleDialogService2(IInnovativeSidePanelService sidePanelService)
 {
-    private PersonModel person = CreatePerson();
+    private PersonFormModel? person;
 
     private readonly List<string> actionLog = [];
 
-    protected override void OnInitialized()
+    protected override void OnInitialized() => person = CreatePerson();
+
+    private PersonFormModel CreatePerson()
     {
-        person.UpdatePasswordAction = count =>
-        {
-            var logEntry = $"Password updated:{count} times";
-            LogAction(logEntry);
-        };
+        var result = new PersonFormModel
+                     { FirstName = "John"
+                     , LastName = "Doe"
+                     , IsActive = true
+                     , BirthDate = new DateTime(year: 1993, month: 5, day: 12)
+                     , ComplexComponent = new ComplexModel
+                                          {
+                                              Name = "Complex Component"
+                                            , Description = "This is a complex component"
+                                          }
+                     , UpdatePasswordAction = count =>
+                                              {
+                                                  var logEntry = $"Password updated:{count} times";
+                                                  LogAction(message: logEntry);
+                                              }
+                     , PasswordCheckAction = isValid =>
+                                             {
+                                                 var logEntry = $"Password checked. Is valid: {isValid}";
+                                                 LogAction(message: logEntry);
+                                             }
+                     , SaveFormAction = () =>
+                                        {
+                                            var logEntry = "Model saved";
+                                            LogAction(logEntry);
+                                            return Task.CompletedTask;
+                                        }
+                     , DeleteFormAction = () =>
+                                          {
+                                              if(person is not null)
+                                              {
+                                                  person.FirstName = null;
+                                                  person.LastName = null;
+                                                  person.IsActive = true;
+                                                  person.BirthDate = null;
+                                              }
+                                              var logEntry = "Model deleted";
+                                              LogAction(message: logEntry);
+                                              return Task.CompletedTask;
+                                          }
+                     , CancelFormAction = () =>
+                                          {
+                                              person = CreatePerson();
+                                              var logEntry = "Model canceled";
+                                              LogAction(message: logEntry);
+                                              return Task.CompletedTask;
+                                          }
+                     };
 
-        person.PasswordCheckAction = isValid =>
-        {
-            var logEntry = $"Password checked. Is valid: {isValid}";
-            LogAction(logEntry);
-        };
-
-        person.SaveFormAction = () =>
-        {
-#pragma warning disable CA2201
-            throw new Exception("This is an exception");
-#pragma warning restore CA2201
-            // var logEntry = "Model saved";
-            // LogAction(logEntry);
-            // return Task.CompletedTask;
-        };
-        person.DeleteFormAction = () =>
-        {
-           person = new PersonModel { IsActive = true };
-           var logEntry = "Model deleted";
-           LogAction(logEntry);
-           return Task.CompletedTask;
-        };
-        person.CancelFormAction = () =>
-        {
-            person = CreatePerson();
-            var logEntry = "Model canceled";
-            LogAction(logEntry);
-            return Task.CompletedTask;
-        };
-
-        base.OnInitialized();
-    }
-
-    private static PersonModel CreatePerson()
-    {
-        var personmodel = new PersonModel
-               {
-                   FirstName = "John",
-                   LastName = "Doe",
-                   IsActive = true,
-                   BirthDate = new DateTime(1993, 5, 12),
-                   ComplexComponent = new()
-                                      {
-                                          Name = "Complex Component",
-                                          Description = "This is a complex component"
-                                      }
-               };
-
-
-        return personmodel;
+        return result;
     }
 
     private void LogAction(string message)
@@ -83,14 +78,27 @@ public partial class ExampleDialogService2(IInnovativeSidePanelService sidePanel
 
     private async Task OpenPersonDialog()
     {
+        person ??= CreatePerson();
         await sidePanelService
-               .OpenInDisplayMode(person)
-               .ConfigureAwait(false);
+              .OpenInDisplayMode(person)
+              .ConfigureAwait(false);
     }
 
     private async Task OpenNewPersonDialog()
     {
-        var newPerson = new PersonModel { IsActive = true };
+        var newPerson = new PersonFormModel
+                        { IsActive = true
+                        , UpdatePasswordAction = count =>
+                                                 {
+                                                     var logEntry = $"Password updated:{count} times";
+                                                     LogAction(message: logEntry);
+                                                 }
+                        , PasswordCheckAction = isValid =>
+                                                {
+                                                    var logEntry = $"Password checked. Is valid: {isValid}";
+                                                    LogAction(message: logEntry);
+                                                }
+        };
 
         await sidePanelService
                            .OpenInEditMode(newPerson)
@@ -99,6 +107,7 @@ public partial class ExampleDialogService2(IInnovativeSidePanelService sidePanel
 
     private async Task OpenLargeWidthDialog()
     {
+        person ??= CreatePerson();
         await sidePanelService
               .OpenInDisplayMode(person, width: SideDialogWidth.Large)
               .ConfigureAwait(false);
@@ -106,6 +115,7 @@ public partial class ExampleDialogService2(IInnovativeSidePanelService sidePanel
 
     private async Task OpenExtraLargeWidthDialog()
     {
+        person ??= CreatePerson();
         await sidePanelService
               .OpenInDisplayMode(person, width: SideDialogWidth.ExtraLarge)
               .ConfigureAwait(false);
@@ -113,13 +123,13 @@ public partial class ExampleDialogService2(IInnovativeSidePanelService sidePanel
 }
 
 [UIFormClass(title: nameof(Example.DialogService_Person), ResourceType = typeof(Example))]
-public class PersonModel : FormModel
+public class PersonFormModel : FormModel
 {
     private const string NameColumn = "Name";
     private const string EmployeeInfoColumn = "EmployeeInfo";
     private const string DescriptionColumn = "Description";
 
-    public PersonModel()
+    public PersonFormModel()
     {
         AddViewColumn(NameColumn, 1, 6, 0);;
         AddViewColumn(EmployeeInfoColumn, 1, 6, 0);

--- a/Src/Innovative.Blazor.Components/Components/Detail/InnovativeDetail.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Detail/InnovativeDetail.razor.cs
@@ -325,17 +325,15 @@ public partial class InnovativeDetail<TModel> : ComponentBase
 
     private List<PropertyInfo> GetActionProperties()
     {
-        List<PropertyInfo> result = typeof(TModel).GetProperties()
-                                                  .Where(predicate: x =>
-                                                                        x.GetCustomAttribute<UIFormViewAction>() != null
-                                                                     && (x.PropertyType == typeof(Action) ||
-                                                                         x.PropertyType.IsGenericType && x.PropertyType.GetGenericTypeDefinition() == typeof(Action<>))
-                                                                     && x.Name                              != nameof(FormModel.SaveFormAction)
-                                                                     && x.Name                              != nameof(FormModel.CancelFormAction)
-                                                                     && x.Name                              != nameof(FormModel.DeleteFormAction)
-                                                                     && x.GetValue(obj: Model, index: null) != null)
-                                                  .OrderBy(keySelector: p => p.GetCustomAttribute<UIFormViewAction>()!.Order)
-                                                  .ToList();
+        var result = typeof(TModel).GetProperties()
+                                   .Where(predicate: x => x.GetCustomAttribute<UIFormViewAction>() != null)
+                                   .Where(predicate: x => x.PropertyType == typeof(Action) || x.PropertyType.IsGenericType && x.PropertyType.GetGenericTypeDefinition() == typeof(Action<>))
+                                   .Where(predicate: x => x.Name                              != nameof(FormModel.SaveFormAction))
+                                   .Where(predicate: x => x.Name                              != nameof(FormModel.CancelFormAction))
+                                   .Where(predicate: x => x.Name                              != nameof(FormModel.DeleteFormAction))
+                                   .Where(predicate: x => x.GetValue(obj: Model, index: null) != null)  // The defined action cannot be null
+                                   .OrderBy(keySelector: x => x.GetCustomAttribute<UIFormViewAction>()!.Order)
+                                   .ToList();
 
         return result;
     }

--- a/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
+++ b/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -30,7 +31,8 @@ public class InnovativeFormTests : LocalizedTestBase
             StringProperty = "Test",
             IntProperty = 42,
             BoolProperty = true,
-            DateProperty = new DateTime(2023, 1, 1)
+            DateProperty = new DateTime(2023, 1, 1),
+            CustomAction = (x) => Debug.WriteLine(x)
         };
 
         var component = new InnovativeForm<TestFormModel>(LocalizerFactoryMock.Object)
@@ -47,6 +49,7 @@ public class InnovativeFormTests : LocalizedTestBase
         Assert.Equal(model.IntProperty, component.GetFormValue("IntProperty"));
         Assert.Equal(model.BoolProperty, component.GetFormValue("BoolProperty"));
         Assert.Equal(model.DateProperty, component.GetFormValue("DateProperty"));
+        Assert.Single(component.GetActions());
     }
 
     [Fact]
@@ -94,7 +97,8 @@ public class InnovativeFormTests : LocalizedTestBase
                         StringProperty = "Test",
                         IntProperty = 42,
                         BoolProperty = true,
-                        DateProperty = new DateTime(2023, 1, 1)
+                        DateProperty = new DateTime(2023, 1, 1),
+                        CustomAction = (x) => Debug.WriteLine(x)
                     };
 
         var expected = new TestFormModel
@@ -102,8 +106,9 @@ public class InnovativeFormTests : LocalizedTestBase
                         StringProperty = actual.StringProperty,
                         IntProperty = actual.IntProperty,
                         BoolProperty = actual.BoolProperty,
-                        DateProperty = actual.DateProperty
-                    };
+                        DateProperty = actual.DateProperty,
+                        CustomAction = actual.CustomAction
+        };
 
         var component = new InnovativeForm<TestFormModel>(LocalizerFactoryMock.Object)
                         {
@@ -127,6 +132,7 @@ public class InnovativeFormTests : LocalizedTestBase
         Assert.Equal(expected.IntProperty, actual.IntProperty);
         Assert.Equal(expected.BoolProperty, actual.BoolProperty);
         Assert.Equal(expected.DateProperty, actual.DateProperty);
+        Assert.Equal(expected.CustomAction, actual.CustomAction);
     }
 
     [Fact]
@@ -213,6 +219,8 @@ public class TestFormModel
     [UIFormField(name: nameof(BoolProperty))] public bool BoolProperty { get; set; }
 
     [UIFormField(name: nameof(DateProperty))] public DateTime DateProperty { get; set; }
+
+    [UIFormViewAction(name: nameof(CustomAction))] public Action<int>? CustomAction { get; set; }
 }
 
 // Extension methods to access private methods/properties for testing
@@ -260,5 +268,15 @@ public static class DynamicFormViewTestExtensions
         var method = typeof(InnovativeForm<T>).GetMethod("GetColumnWidthClass",
                                                                     BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
         return (string)method!.Invoke(component, [columnGroup])!;
+    }
+
+    public static IReadOnlyCollection<PropertyInfo> GetActions<T>(this InnovativeForm<T> component)
+    {
+        var properties = component?.Model?.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance) ?? [];
+        var result = properties
+                .Where(x=> x.GetCustomAttribute<UIFormViewAction>() !=null)
+                .ToList()
+                .AsReadOnly();
+        return result;
     }
 }


### PR DESCRIPTION
The cause of this error in **not** in the components library. 

It was (is) an implementation issue: when creating a new instance of a form model, with custom actions defined, the new instance need to have the custom actions also be defined. 

If a custom action is null, the corresponding button will not be rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Person form updated with an added Description field.

- Improvements
  - Dialogs now ensure the form is initialized before opening, improving reliability.
  - Password validation and update screens aligned with the updated person form.
  - Action buttons on forms are preserved after reset and consistently detected.

- Refactor
  - Internal action filtering streamlined for maintainability (no user-visible changes).

- Tests
  - Expanded test coverage for action discovery and preservation across form lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->