### PR TITLE
Task #179: Add support for form validation

### DIFF
--- a/ExampleApp/ExampleDataSet.cs
+++ b/ExampleApp/ExampleDataSet.cs
@@ -19,6 +19,8 @@ public class ExampleDataSet
         faker.RuleFor(property: p => p.LastName, setter: f => f.Person.LastName);
         faker.RuleFor(property: p => p.DateOfBirth, setter: f => DateOnly.FromDateTime(dateTime: f.Person.DateOfBirth));
         faker.RuleFor(property: p => p.Income, setter: f => f.Random.Decimal(min: 20000, max: 80000));
+        faker.RuleFor(property: p => p.EmailAddress, setter: f => f.Person.Email);
+        faker.RuleFor(property: p => p.Phone, setter: f => f.Person.Phone);
 
         var data = faker.Generate(count: amount);
         Data.Clear();
@@ -33,5 +35,7 @@ public sealed record PersonModel
     public required string LastName { get; init; }
     public required DateOnly DateOfBirth { get; init; }
     public required decimal Income { get; init; }
+    public string? EmailAddress { get; init; }
+    public string? Phone { get; init; }
     public override string ToString() => $"{FirstName} {LastName}";
 }

--- a/ExampleApp/Layout/NavMenu.razor
+++ b/ExampleApp/Layout/NavMenu.razor
@@ -53,6 +53,9 @@
                 <NavLink class="nav-link" href="grid/complex/5">
                     <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Complex Grid 5
                 </NavLink>
+                <NavLink class="nav-link" href="grid/complex/6">
+                    <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Complex Grid 6
+                </NavLink>
             </div>
         </div>
         <div class="nav-item px-3">

--- a/ExampleApp/Pages/ExampleComplexGrid6.razor
+++ b/ExampleApp/Pages/ExampleComplexGrid6.razor
@@ -3,7 +3,7 @@
 @using Innovative.Blazor.Components.Components
 
 <h3> Grid Example 6</h3>
-<p>Shows a large multipage grid with several display options in the side panel.</p>
+<p>Shows a large multipage grid with several display options and form validations in the side panel.</p>
 <p>
     Current locale: @CultureInfo.CurrentCulture.Name (@CultureInfo.CurrentCulture.TwoLetterISOLanguageName / @CultureInfo.CurrentCulture.ThreeLetterISOLanguageName)
 </p>

--- a/ExampleApp/Pages/ExampleComplexGrid6.razor.cs
+++ b/ExampleApp/Pages/ExampleComplexGrid6.razor.cs
@@ -36,6 +36,8 @@ public partial class ExampleComplexGrid6(IInnovativeSidePanelService sidePanelSe
                                        item.DateOfBirth = model.DateOfBirth is null
                                                               ? string.Empty
                                                               : model.DateOfBirth.Value.ToDateString();
+                                       item.EmailAddress = model.EmailAddress;
+                                       item.Phone = model.Phone;
                                        return Task.CompletedTask;
                                    };
 

--- a/ExampleApp/Pages/ExampleComplexGrid6.razor.cs
+++ b/ExampleApp/Pages/ExampleComplexGrid6.razor.cs
@@ -30,8 +30,12 @@ public partial class ExampleComplexGrid6(IInnovativeSidePanelService sidePanelSe
                                        Person6GridModel item = items.Single(predicate: x => x.Id == model.Id);
                                        item.FirstName = model.FirstName;
                                        item.LastName = model.LastName;
-                                       item.Income = model.Income.ToCurrencyString();
-                                       item.DateOfBirth = model.DateOfBirth.ToDateString();
+                                       item.Income = model.Income is null
+                                                         ? string.Empty
+                                                         : model.Income.Value.ToCurrencyString();
+                                       item.DateOfBirth = model.DateOfBirth is null
+                                                              ? string.Empty
+                                                              : model.DateOfBirth.Value.ToDateString();
                                        return Task.CompletedTask;
                                    };
 
@@ -60,6 +64,7 @@ public sealed class Person6GridModel
     public required string Income { get; set; }
 
     public string? EmailAddress { get; set; }
+
     public string? Phone { get; set; }
 
     public static Person6GridModel ToGridModel([NotNull] PersonModel instance)
@@ -122,13 +127,13 @@ public sealed class Person6FormModel : FormModel
 
     [UIFormField(name: "DateOfBirth", ColumnGroup = ColumnGroup2, FormParameters = [$"DateFormat={Constants.DateFormat}"], DisplayParameters = ["Format={0:dddd d MMMM yyyy}"])]
     [Required]
-    public required DateTime DateOfBirth { get; set; }
+    public required DateTime? DateOfBirth { get; set; }
 
     [UIFormField(name: "Age", ColumnGroup = ColumnGroup3)]
-    public int Age => DateOfBirth.Age();
+    public int Age => DateOfBirth?.Age() ?? 0;
 
     [UIFormField(name: "Income", ColumnGroup = ColumnGroup4, FormParameters = [$"Format={Constants.CurrencyFormat}"], DisplayParameters = [$"Format={Constants.CurrencyFormat}"])]
-    public required decimal Income { get; set; }
+    public decimal? Income { get; set; }
 
     [UIFormField(name: "Email", ColumnGroup = ColumnGroup5)]
     [Required]
@@ -142,14 +147,13 @@ public sealed class Person6FormModel : FormModel
     public static Person6FormModel ToFormModel([NotNull] PersonModel instance)
     {
         return new Person6FormModel
-               {
-                   Id = instance.Id
-                 , FirstName = instance.FirstName
-                 , LastName = instance.LastName
-                 , Income = instance.Income
-                 , DateOfBirth = instance.DateOfBirth.ToDateTime(time: TimeOnly.MinValue),
-                  EmailAddress = instance.EmailAddress,
-                  Phone = instance.Phone
-        };
+               { Id = instance.Id
+               , FirstName = instance.FirstName
+               , LastName = instance.LastName
+               , Income = instance.Income
+               , DateOfBirth = instance.DateOfBirth.ToDateTime(time: TimeOnly.MinValue)
+               , EmailAddress = instance.EmailAddress
+               , Phone = instance.Phone
+               };
     }
 }

--- a/ExampleApp/Pages/ExampleComplexGrid6.razor.cs
+++ b/ExampleApp/Pages/ExampleComplexGrid6.razor.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using ExampleApp.Translations;
 using Innovative.Blazor.Components.Components;
@@ -13,7 +14,7 @@ public partial class ExampleComplexGrid6(IInnovativeSidePanelService sidePanelSe
     {
         if (items.Count == 0)
         {
-            ExampleDataSet.Instance.GenerateTestData(180);
+            ExampleDataSet.Instance.GenerateTestData(amount: 180);
             items.AddRange(collection: ExampleDataSet.Instance.Data.Select(selector: Person6GridModel.ToGridModel));
         }
     }
@@ -50,13 +51,16 @@ public sealed class Person6GridModel
     public required string FirstName { get; set; }
 
     [UIGridField(Name = "LastName")]
-    public required string LastName { get; set; }
+    public required string LastName { get; set; }  
 
     [UIGridField(Name = "DateOfBirth")]
     public required string DateOfBirth { get; set; }
 
     [UIGridField(Name = "Income")]
     public required string Income { get; set; }
+
+    public string? EmailAddress { get; set; }
+    public string? Phone { get; set; }
 
     public static Person6GridModel ToGridModel([NotNull] PersonModel instance)
     {
@@ -67,17 +71,21 @@ public sealed class Person6GridModel
                  , LastName = instance.LastName
                  , Income = instance.Income.ToCurrencyString()
                  , DateOfBirth = instance.DateOfBirth.ToDateString()
+                 , EmailAddress = instance.EmailAddress
+                 , Phone = instance.Phone
                };
     }
 
     public static PersonModel ToModel([NotNull] Person6GridModel instance) => new PersonModel
-                                                                               {
-                                                                                   Id = instance.Id
-                                                                                 , FirstName = instance.FirstName
-                                                                                 , LastName = instance.LastName
-                                                                                 , Income = instance.Income.ToCurrency()
-                                                                                 , DateOfBirth = instance.DateOfBirth.ToDate()
-                                                                               };
+                                                                              {
+                                                                                  Id = instance.Id
+                                                                                , FirstName = instance.FirstName
+                                                                                , LastName = instance.LastName
+                                                                                , Income = instance.Income.ToCurrency()
+                                                                                , DateOfBirth = instance.DateOfBirth.ToDate()
+                                                                                , EmailAddress = instance.EmailAddress
+                                                                                , Phone = instance.Phone
+                                                                              };
 }
 
 [UIFormClass(title: "Person", ResourceType = typeof(Example))]
@@ -87,6 +95,7 @@ public sealed class Person6FormModel : FormModel
     private const string ColumnGroup2 = "PropertyColumn2";
     private const string ColumnGroup3 = "PropertyColumn3";
     private const string ColumnGroup4 = "PropertyColumn4";
+    private const string ColumnGroup5 = "PropertyColumn5";
 
     public Person6FormModel()
     {
@@ -94,17 +103,25 @@ public sealed class Person6FormModel : FormModel
         AddViewColumn(name: ColumnGroup2, width: 6, order: 1, offset: 0);
         AddViewColumn(name: ColumnGroup3, width: 6, order: 1, offset: 0);
         AddViewColumn(name: ColumnGroup4, width: 6, order: 1, offset: 0);
+        AddViewColumn(name: ColumnGroup5, width: 12, order: 1, offset: 0);
     }
 
     public Guid Id { get; set; }
 
     [UIFormField(name: "FirstName", ColumnGroup = ColumnGroup1)]
+    [Required]
+    [MinLength(2)]
+    [MaxLength(24)]
     public required string FirstName { get; set; }
 
     [UIFormField(name: "LastName", ColumnGroup = ColumnGroup1)]
+    [Required]
+    [MinLength(2)]
+    [MaxLength(48)]
     public required string LastName { get; set; }
 
     [UIFormField(name: "DateOfBirth", ColumnGroup = ColumnGroup2, FormParameters = [$"DateFormat={Constants.DateFormat}"], DisplayParameters = ["Format={0:dddd d MMMM yyyy}"])]
+    [Required]
     public required DateTime DateOfBirth { get; set; }
 
     [UIFormField(name: "Age", ColumnGroup = ColumnGroup3)]
@@ -113,6 +130,15 @@ public sealed class Person6FormModel : FormModel
     [UIFormField(name: "Income", ColumnGroup = ColumnGroup4, FormParameters = [$"Format={Constants.CurrencyFormat}"], DisplayParameters = [$"Format={Constants.CurrencyFormat}"])]
     public required decimal Income { get; set; }
 
+    [UIFormField(name: "Email", ColumnGroup = ColumnGroup5)]
+    [Required]
+    [EmailAddress(ErrorMessageResourceType = typeof(Example), ErrorMessageResourceName = "EmailAddressValidation")]
+    public string? EmailAddress { get; set; }
+
+    [UIFormField(name: "Phone", ColumnGroup = ColumnGroup5)]
+    [Phone(ErrorMessageResourceType = typeof(Example), ErrorMessageResourceName = "PhoneNumberValidation")]
+    public string? Phone { get; set; }
+    
     public static Person6FormModel ToFormModel([NotNull] PersonModel instance)
     {
         return new Person6FormModel
@@ -121,7 +147,9 @@ public sealed class Person6FormModel : FormModel
                  , FirstName = instance.FirstName
                  , LastName = instance.LastName
                  , Income = instance.Income
-                 , DateOfBirth = instance.DateOfBirth.ToDateTime(TimeOnly.MinValue)
-               };
+                 , DateOfBirth = instance.DateOfBirth.ToDateTime(time: TimeOnly.MinValue),
+                  EmailAddress = instance.EmailAddress,
+                  Phone = instance.Phone
+        };
     }
 }

--- a/ExampleApp/Translations/Example.Designer.cs
+++ b/ExampleApp/Translations/Example.Designer.cs
@@ -88,6 +88,15 @@ namespace ExampleApp.Translations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The email adres provided doesn&apos;t look like a valid one.
+        /// </summary>
+        internal static string EmailAddressValidation {
+            get {
+                return ResourceManager.GetString("EmailAddressValidation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to First name/Voornaam.
         /// </summary>
         internal static string FirstName {
@@ -111,6 +120,15 @@ namespace ExampleApp.Translations {
         internal static string Person {
             get {
                 return ResourceManager.GetString("Person", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The phone number provided doesn&apos;t look like a valid one.
+        /// </summary>
+        internal static string PhoneNumberValidation {
+            get {
+                return ResourceManager.GetString("PhoneNumberValidation", resourceCulture);
             }
         }
     }

--- a/ExampleApp/Translations/Example.en-US.resx
+++ b/ExampleApp/Translations/Example.en-US.resx
@@ -126,6 +126,9 @@
   <data name="DialogService_Person" xml:space="preserve">
     <value>Person</value>
   </data>
+  <data name="EmailAddressValidation" xml:space="preserve">
+    <value>The email address provided doesn't look like a valid one</value>
+  </data>
   <data name="FirstName" xml:space="preserve">
     <value>First name</value>
   </data>
@@ -134,5 +137,8 @@
   </data>
   <data name="Person" xml:space="preserve">
     <value>Person</value>
+  </data>
+  <data name="PhoneNumberValidation" xml:space="preserve">
+    <value>The phone number provided doesn't look like a valid one</value>
   </data>
 </root>

--- a/ExampleApp/Translations/Example.nl-NL.resx
+++ b/ExampleApp/Translations/Example.nl-NL.resx
@@ -139,6 +139,6 @@
     <value>Persoon</value>
   </data>
   <data name="PhoneNumberValidation" xml:space="preserve">
-    <value>Het opgegeven telefoonnummer lijkt niet vilide te zijn</value>
+    <value>Het opgegeven telefoonnummer lijkt niet valide te zijn</value>
   </data>
 </root>

--- a/ExampleApp/Translations/Example.nl-NL.resx
+++ b/ExampleApp/Translations/Example.nl-NL.resx
@@ -127,7 +127,7 @@
     <value>Persoon</value>
   </data>
   <data name="EmailAddressValidation" xml:space="preserve">
-    <value>Het opgegeven emailadres lijkt niet vilide te zijn</value>
+    <value>Het opgegeven emailadres lijkt niet valide te zijn</value>
   </data>
   <data name="FirstName" xml:space="preserve">
     <value>Voornaam</value>

--- a/ExampleApp/Translations/Example.nl-NL.resx
+++ b/ExampleApp/Translations/Example.nl-NL.resx
@@ -126,6 +126,9 @@
   <data name="DialogService_Person" xml:space="preserve">
     <value>Persoon</value>
   </data>
+  <data name="EmailAddressValidation" xml:space="preserve">
+    <value>Het opgegeven emailadres lijkt niet vilide te zijn</value>
+  </data>
   <data name="FirstName" xml:space="preserve">
     <value>Voornaam</value>
   </data>
@@ -134,5 +137,8 @@
   </data>
   <data name="Person" xml:space="preserve">
     <value>Persoon</value>
+  </data>
+  <data name="PhoneNumberValidation" xml:space="preserve">
+    <value>Het opgegeven telefoonnummer lijkt niet vilide te zijn</value>
   </data>
 </root>

--- a/ExampleApp/Translations/Example.resx
+++ b/ExampleApp/Translations/Example.resx
@@ -126,6 +126,9 @@
   <data name="DialogService_Person" xml:space="preserve">
     <value>Persoon/Person</value>
   </data>
+  <data name="EmailAddressValidation" xml:space="preserve">
+    <value>The email adres provided doesn't look like a valid one</value>
+  </data>
   <data name="FirstName" xml:space="preserve">
     <value>First name/Voornaam</value>
   </data>
@@ -134,5 +137,8 @@
   </data>
   <data name="Person" xml:space="preserve">
     <value>Persoon/Person</value>
+  </data>
+  <data name="PhoneNumberValidation" xml:space="preserve">
+    <value>The phone number provided doesn't look like a valid one</value>
   </data>
 </root>

--- a/ExampleApp/Translations/Example.resx
+++ b/ExampleApp/Translations/Example.resx
@@ -127,7 +127,7 @@
     <value>Persoon/Person</value>
   </data>
   <data name="EmailAddressValidation" xml:space="preserve">
-    <value>The email adres provided doesn't look like a valid one</value>
+    <value>The email address provided doesn't look like a valid one</value>
   </data>
   <data name="FirstName" xml:space="preserve">
     <value>First name/Voornaam</value>

--- a/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
@@ -8,10 +8,11 @@ namespace Innovative.Blazor.Components.Components;
 
 public abstract class FormModel
 {
-    private readonly List<string> exceptions = [];
+    private readonly Dictionary<string, HashSet<string>> exceptions = [];
+
     protected Collection<Column> ViewColumns { get; } = [];
 
-    public IEnumerable<string> Exceptions => exceptions;
+    public IEnumerable<string> Exceptions => exceptions.SelectMany(x=>x.Value);
 
     /// <summary>
     /// The name (used as caption or label) of the form component.
@@ -52,105 +53,117 @@ public abstract class FormModel
 
     public async Task AddExceptionAsync(Exception exception)
     {
-        Debug.Assert(exception != null, nameof(exception) + " != null");
+        Debug.Assert(exception != null, $"Parameter {nameof(exception)} is null!");
+
         var exceptionName = exception.GetType().Name;
 
-        if (exceptionName == "MicrosoftAspNetCoreMvcProblemDetails" || exceptionName.StartsWith("ProblemDetails",StringComparison.InvariantCulture ) )
+        if (IsProblemDetails(exceptionName))
         {
-            PropertyInfo? additionalDataProp = exception.GetType().GetProperty("AdditionalData");
-            //additionalData is a dictionary of string keys and object values
-            //this should be use the get the errors
-
-
-            if (additionalDataProp != null)
-            {
-                if (additionalDataProp.GetValue(exception) is IDictionary<string, object> additionalData)
-                {
-
-                    // Check if the additionalData contains an "errors" key and cast object as Erros class
-#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-                    if (additionalData.TryGetValue("errors", out dynamic errorsObj))
-#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
-                    {
-                        var serializedData = await KiotaJsonSerializer.SerializeAsStringAsync(errorsObj);
-
-                        var root = JsonNode.Parse(serializedData); // of JsonDocument, zie alternatief onderaan
-
-                        if (root is JsonObject obj)
-                        {
-                            foreach (var kvp in obj)
-                            {
-                                if (kvp.Value is JsonArray arr)
-                                {
-                                    var errorString = string.Empty;
-                                    foreach (var item in arr)
-                                    {
-                                        if (item is JsonValue value)
-                                        {
-                                            errorString += value.ToString() + "<br/> ";
-                                        }
-                                    }
-                                    exceptions.Add(errorString);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            foreach (var kvp in additionalData)
-                            {
-                                exceptions.Add(kvp.Value.ToString()!);
-                            }
-                            // Check if the additionalData contains an "errors" key and cast object as Erros class
-                        }
-                    }
-                }
-            }
+            AddExceptions(exceptionName, await GetErrorMessagesFromAdditionalDataAsync(exception)
+                                             .ConfigureAwait(continueOnCapturedContext: false));
         }
-        else if (exceptionName.Equals("ErrorResponse", StringComparison.OrdinalIgnoreCase))
+        else if (IsErrorResponse(exceptionName))
         {
-            PropertyInfo? additionalDataProp = exception.GetType().GetProperty("Errors");
-            var values = additionalDataProp?.GetValue(exception) as dynamic;
-            //get the AdditionalData property from the values
-            var additionalData = values?.AdditionalData;
-
-            var serializedData =   await KiotaJsonSerializer.SerializeAsStringAsync(additionalData);
-            var root = JsonNode.Parse(serializedData); // of JsonDocument, zie alternatief onderaan
-
-            if (root is JsonObject obj)
-            {
-                foreach (var kvp in obj)
-                {
-                    if (kvp.Value is JsonArray arr)
-                    {
-                        var errorString = string.Empty;
-                        foreach (var item in arr)
-                        {
-                            if (item is JsonValue value)
-                            {
-                                errorString += value.ToString() + "<br/> ";
-                            }
-                        }
-                        exceptions.Add(errorString);
-                    }
-                }
-            }
-
+            AddExceptions(exceptionName, await GetErrorMessagesFromErrorResponseAsync(exception)
+                                             .ConfigureAwait(continueOnCapturedContext: false));
         }
         else
         {
-            exceptions.Add(exception.Message);
+            AddException(exceptionName, exception.Message);
         }
     }
-    public void AddException(string key, string message) => exceptions.Add(message);
 
-    public void ClearExceptions()
+    private static bool IsProblemDetails(string exceptionName) => exceptionName == "MicrosoftAspNetCoreMvcProblemDetails"
+                                                               || exceptionName.StartsWith(value: "ProblemDetails", comparisonType: StringComparison.InvariantCulture);
+
+    private static bool IsErrorResponse(string exceptionName) => exceptionName.Equals(value: "ErrorResponse", comparisonType: StringComparison.OrdinalIgnoreCase);
+
+    private static async Task<List<string>> GetErrorMessagesFromAdditionalDataAsync(Exception exception)
     {
-        exceptions.Clear();
+        // additionalData is a dictionary of string keys and object values
+        // this should be used to the get the errors
+        PropertyInfo? additionalDataProp = exception.GetType().GetProperty("AdditionalData");
+
+        if (additionalDataProp?.GetValue(exception) is not IDictionary<string, object> additionalData)
+        {
+            return [];
+        }
+
+        // Check if the additionalData contains an "errors" key and cast object as Errors class
+        return additionalData.TryGetValue("errors", out dynamic? errorsObj)
+                    ? await GetErrorMessagesAsync(errorsObj)
+                    : additionalData.Select(kvp => $"{kvp.Key} = {kvp.Value}")
+                                    .ToList();
     }
-}
 
-public class ErrorResponseDetails
-{
-    public Dictionary<string, object>? AdditionalData { get;  }
-}
+    private static async Task<List<string>> GetErrorMessagesFromErrorResponseAsync(Exception exception)
+    {
+        PropertyInfo? errorsProp = exception.GetType().GetProperty("Errors");
+        dynamic? values = errorsProp?.GetValue(exception);
+        var errorsObj = values?.AdditionalData;
 
+        return await GetErrorMessagesAsync(errorsObj);
+    }
+
+    private static async Task<List<string>> GetErrorMessagesAsync(dynamic? errorsObj)
+    {
+        if(errorsObj is null)
+            return [];
+
+        string serializedData = await KiotaJsonSerializer.SerializeAsStringAsync(errorsObj);
+        var root = JsonNode.Parse(serializedData);
+
+        if (root is not JsonObject jsonObject)
+            return [];
+
+        List<string> result = [];
+        foreach (KeyValuePair<string, JsonNode?> kvp in jsonObject)
+        {
+            if (kvp.Value is not JsonArray jsonArray)
+                continue;
+
+            foreach (var item in jsonArray)
+            {
+                if (item is JsonValue value)
+                    result.Add(value.ToString());
+            }
+        }
+
+        return result;
+    }
+
+    public void AddExceptions(string key, IEnumerable<string> messages)
+    {
+        var exceptionMessages = messages.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+        if(exceptionMessages.Count == 0)
+            return;
+
+        foreach (var message in exceptionMessages)
+        {
+            AddException(key, message);
+        }
+    }
+
+    public void AddException(string key, string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return;
+
+        if (exceptions.TryGetValue(key, out var value))
+        {
+            value.Add(message);
+            return;
+        }
+
+        exceptions[key] = new HashSet<string>();
+        exceptions[key].Add(message);
+    }
+
+    public void RemoveException(Exception exception)
+    {
+        Debug.Assert(exception != null, $"Parameter {nameof(exception)} is null!");
+        _ = exceptions.Remove(exception.GetType().Name);
+    }
+    public void RemoveException(string key) => _ = exceptions.Remove(key);
+    public void ClearExceptions() => exceptions.Clear();
+}

--- a/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
@@ -135,7 +135,7 @@ public abstract class FormModel
     public void AddExceptions(string key, IEnumerable<string> messages)
     {
         var exceptionMessages = messages.Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
-        if(exceptionMessages.Count == 0)
+        if (exceptionMessages.Count == 0)
             return;
 
         foreach (var message in exceptionMessages)

--- a/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
@@ -107,7 +107,7 @@ public abstract class FormModel
 
     private static async Task<List<string>> GetErrorMessagesAsync(dynamic? errorsObj)
     {
-        if(errorsObj is null)
+        if (errorsObj is null)
             return [];
 
         string serializedData = await KiotaJsonSerializer.SerializeAsStringAsync(errorsObj);

--- a/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
@@ -53,7 +53,7 @@ public abstract class FormModel
 
     public async Task AddExceptionAsync(Exception exception)
     {
-        Debug.Assert(exception != null, $"Parameter {nameof(exception)} is null!");
+        ArgumentNullException.ThrowIfNull(exception);
 
         var exceptionName = exception.GetType().Name;
 
@@ -161,7 +161,7 @@ public abstract class FormModel
 
     public void RemoveException(Exception exception)
     {
-        Debug.Assert(exception != null, $"Parameter {nameof(exception)} is null!");
+        ArgumentNullException.ThrowIfNull(exception);
         _ = exceptions.Remove(exception.GetType().Name);
     }
     public void RemoveException(string key) => _ = exceptions.Remove(key);

--- a/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.Reflection;
+  using System.Reflection;
 using System.Text.Json.Nodes;
 using Microsoft.Kiota.Abstractions.Serialization;
 
@@ -73,7 +72,7 @@ public abstract class FormModel
         }
     }
 
-    private static bool IsProblemDetails(string exceptionName) => exceptionName == "MicrosoftAspNetCoreMvcProblemDetails"
+    private static bool IsProblemDetails(string exceptionName) => exceptionName.Equals(value: "MicrosoftAspNetCoreMvcProblemDetails", comparisonType: StringComparison.Ordinal)
                                                                || exceptionName.StartsWith(value: "ProblemDetails", comparisonType: StringComparison.InvariantCulture);
 
     private static bool IsErrorResponse(string exceptionName) => exceptionName.Equals(value: "ErrorResponse", comparisonType: StringComparison.OrdinalIgnoreCase);

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor
@@ -1,4 +1,5 @@
 @namespace Innovative.Blazor.Components.Components
+@using System.Diagnostics
 @using System.Reflection
 @typeparam TModel
 
@@ -6,7 +7,7 @@
     <section class="innovative-form-layout">
         @{
             var model = Model as FormModel;
-            System.Diagnostics.Debug.Assert(model != null, $"{nameof(model)} is null!");
+            Debug.Assert(model != null, $"{nameof(model)} is null!");
             foreach (var exception in model.Exceptions)
             {
                 <section class="rz-alert rz-background-color-danger-lighter gap-2 column-span-4">

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
@@ -404,7 +404,7 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
     private void SetValue(string propertyName, object? value, bool shouldNotifyChange = false)
     {
         formValues[key: propertyName] = value;
-        AddValidationErrors(propertyName,value);
+        AddValidationErrors(propertyName, value);
         if (shouldNotifyChange)
         {
             NotifyPropertyChanged(propertyName: propertyName, value: value);

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
@@ -453,7 +453,7 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
                             .Where(attr => attr.GetType().IsSubclassOf(typeof(ValidationAttribute)))
                             .Cast<ValidationAttribute>()
                             .Where(x => !x.IsValid(value))
-                            .Select(x=> x.FormatErrorMessage(propertyName))
+                            .Select(x => x.FormatErrorMessage(propertyName))
                             .ToList();
 
         model.AddExceptions(propertyName, errorMessages);

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -403,6 +404,7 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
     private void SetValue(string propertyName, object? value, bool shouldNotifyChange = false)
     {
         formValues[key: propertyName] = value;
+        AddValidationErrors(propertyName,value);
         if (shouldNotifyChange)
         {
             NotifyPropertyChanged(propertyName: propertyName, value: value);
@@ -435,4 +437,25 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
         => formField?.FormParameters == null
         || !formField.FormParameters.Contains("DisplayLabel=false", StringComparer.InvariantCultureIgnoreCase);
 
+    private void AddValidationErrors(string propertyName, object? value)
+    {
+        if (Model is not FormModel model)
+            return;
+
+        var property = typeof(TModel).GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+        if (property is null)
+            return;
+
+        model.RemoveException(propertyName);
+
+        var errorMessages = property
+                            .GetCustomAttributes(inherit: true)
+                            .Where(attr => attr.GetType().IsSubclassOf(typeof(ValidationAttribute)))
+                            .Cast<ValidationAttribute>()
+                            .Where(x=> !x.IsValid(value))
+                            .Select(x=> x.FormatErrorMessage(propertyName))
+                            .ToList();
+
+        model.AddExceptions(propertyName, errorMessages);
+    }
 }

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
@@ -38,17 +38,20 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
 
     protected override void OnParametersSet()
     {
-        if (ParentDialog != null && Model is FormModel)
+        if (ParentDialog != null && Model is FormModel model)
         {
             ParentDialog.SetFormComponent(this);
-        }
 
-        foreach (var prop in GetPropertiesWithUiFormField())
-        {
-            formValues[key: prop.Name] = prop.GetValue(obj: Model);
-        }
+            if (!model.Exceptions.Any())
+            {
+                foreach (var prop in GetPropertiesWithUiFormField())
+                {
+                    formValues[key: prop.Name] = prop.GetValue(obj: Model);
+                }
+            }
 
-        OrganizePropertiesByGroups();
+            OrganizePropertiesByGroups();
+        }
     }
 
     private void OrganizePropertiesByGroups()
@@ -92,6 +95,10 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
 
     public Task OnFormSubmit()
     {
+        // Do not write the form values back to the model if the model has exceptions
+        if (Model is FormModel model && model.Exceptions.Any())
+            return Task.CompletedTask;
+
         foreach (var entry in formValues)
         {
             var prop = typeof(TModel).GetProperty(name: entry.Key);

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
@@ -452,7 +452,7 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
                             .GetCustomAttributes(inherit: true)
                             .Where(attr => attr.GetType().IsSubclassOf(typeof(ValidationAttribute)))
                             .Cast<ValidationAttribute>()
-                            .Where(x=> !x.IsValid(value))
+                            .Where(x => !x.IsValid(value))
                             .Select(x=> x.FormatErrorMessage(propertyName))
                             .ToList();
 

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
@@ -446,16 +446,29 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
         if (property is null)
             return;
 
+        var hasValidators = property
+                            .GetCustomAttributes(inherit: true)
+                            .Any(attr => attr.GetType().IsSubclassOf(typeof(ValidationAttribute)));
+
+        if (!hasValidators)
+            return;
+
         model.RemoveException(propertyName);
 
-        var errorMessages = property
-                            .GetCustomAttributes(inherit: true)
-                            .Where(attr => attr.GetType().IsSubclassOf(typeof(ValidationAttribute)))
-                            .Cast<ValidationAttribute>()
-                            .Where(x => !x.IsValid(value))
-                            .Select(x => x.FormatErrorMessage(propertyName))
-                            .ToList();
+        var results = new List<ValidationResult>();
 
-        model.AddExceptions(propertyName, errorMessages);
+        LocalizedString displayName = localizer[name: property.GetCustomAttribute<UIFormField>()?.Name ?? propertyName];
+        var context = new ValidationContext(instance: model)
+                      { MemberName = propertyName
+                      , DisplayName = displayName
+                      };
+        _ = Validator.TryValidateProperty(value: value, validationContext: context, validationResults: results);
+
+        var messages = results
+                       .Where(predicate: x => !string.IsNullOrWhiteSpace(value: x.ErrorMessage))!
+                       .Select(selector: x => x.ErrorMessage!)
+                       .ToList();
+
+        model.AddExceptions(propertyName, messages);
     }
 }

--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.cs
@@ -10,6 +10,8 @@ public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelServi
 {
     private IFormComponent? formComponent;
     private bool isCustomDialog;
+    private string? modelError;
+
     [Parameter] public bool IsEditing { get; set; }
     [Parameter] public bool ShowClose { get; set; } = true;
     [Parameter] public bool ShowEdit { get; set; } = true;
@@ -22,14 +24,9 @@ public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelServi
     [Parameter] public RenderFragment? EditChildContent { get; set; }
     [Parameter] public TModel? Model { get; set; }
     [Parameter] public string? DataTestId { get; set; }
-
     [Parameter] public string? Title { get; set; }
-
     [Parameter] public bool CloseOnSaveForm { get; set; } = false;
-
     [Parameter] public bool IsNewModel { get; set; } = false;
-
-    private string? modelError;
 
     public object? ComponentInstance { get; private set; }
 
@@ -50,6 +47,7 @@ public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelServi
         {
             return;
         }
+
         StateHasChanged();
     }
     public void CloseCustomDialog()
@@ -64,37 +62,32 @@ public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelServi
 
     protected override void OnParametersSet()
     {
-        base.OnParametersSet();
-        if (Model is not null && Model is not FormModel)
-        {
-            modelError = $"Cannot render model of type '{Model.GetType().Name}'. Only FormModel types are supported.";
-        }
-        else
-        {
-            modelError = null;
-        }
+        modelError = Model is not null && Model is not FormModel
+                         ? $"Cannot render model of type '{Model.GetType().Name}'. Only {nameof(FormModel)} types are supported."
+                         : null;
     }
 
     private async Task HandleSaveClick()
     {
         if (modelError != null)
-        {
             return;
-        }
-        if (formComponent is not null)
-        {
-            await formComponent
-                  .OnFormSubmit()
-                  .ConfigureAwait(true);
-        }
 
         if (Model is FormModel model)
         {
+            if (model.Exceptions.Any())
+                return;
+
+            if (formComponent is not null)
+                await formComponent
+                      .OnFormSubmit()
+                      .ConfigureAwait(continueOnCapturedContext: true);
+
             try
             {
                 if (model.SaveFormAction is not null)
                 {
-                    await model.SaveFormAction!.Invoke().ConfigureAwait(true);
+                    await model.SaveFormAction.Invoke()
+                               .ConfigureAwait(continueOnCapturedContext: true);
                     IsNewModel = false;
                 }
                 if (CloseOnSaveForm)
@@ -106,48 +99,33 @@ public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelServi
             }
             catch (Exception e)
             {
-                await model.AddExceptionAsync(e).ConfigureAwait(false);
+                await model.AddExceptionAsync(exception: e)
+                           .ConfigureAwait(continueOnCapturedContext: false);
             }
             StateHasChanged();
-        }
-        else
-        {
-            if (CloseOnSaveForm)
-            {
-
-                sidePanelService.CloseSidepanel();
-            }
-            isCustomDialog = false;
-            IsEditing = false;
         }
     }
 
     private async Task HandleDeleteClick()
     {
-
         if (Model is FormModel model)
         {
             try
             {
                 if (model.DeleteFormAction is not null)
-                {
-                    await (model.DeleteFormAction.Invoke()!).ConfigureAwait(true);
-                }
+                    await model.DeleteFormAction.Invoke()
+                               .ConfigureAwait(continueOnCapturedContext: true);
+
                 isCustomDialog = false;
                 IsEditing = false;
                 sidePanelService.CloseSidepanel();
             }
             catch (Exception e)
             {
-                await model.AddExceptionAsync(e).ConfigureAwait(false);
+                await model.AddExceptionAsync(exception: e)
+                           .ConfigureAwait(continueOnCapturedContext: false);
             }
         }
-        else
-        {
-            sidePanelService.CloseSidepanel();
-        }
-        isCustomDialog = false;
-        IsEditing = false;
     }
 
     private async Task HandleCancelClick()
@@ -163,21 +141,20 @@ public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelServi
             try
             {
                 if(model.CancelFormAction is not null)
-                    await (model.CancelFormAction!.Invoke()!).ConfigureAwait(true);
+                    await model.CancelFormAction.Invoke()
+                               .ConfigureAwait(continueOnCapturedContext: true);
+
+                model.ClearExceptions();
+
                 IsEditing = false;
                 isCustomDialog = false;
                 ActionChildContent = null;
             }
             catch (Exception e)
             {
-                await model.AddExceptionAsync(e).ConfigureAwait(false);
+                await model.AddExceptionAsync(exception: e)
+                           .ConfigureAwait(continueOnCapturedContext: false);
             }
-        }
-        else
-        {
-            IsEditing = false;
-            isCustomDialog = false;
-            ActionChildContent = null;
         }
     }
 }


### PR DESCRIPTION
Added support for form validation with `System.ComponentModel.DataAnnotations` attributes.
See example app, grid 6.
https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations?view=net-9.0

Best te be reviewed per commit.

**Note:** unit tests to be added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Email and Phone fields to Complex Grid 6 form and grid with UI validation and localized messages.
  - Navigation link added for "Complex Grid 6".

- **Improvements**
  - Test data now includes email and phone values.
  - Real-time per-field validation on edits; saving blocked until validation passes.
  - Form error handling improved: per-field, deduplicated messages with add/remove/clear capabilities.

- **Documentation**
  - Updated descriptive text to mention form validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->