### PR TITLE
Provide skeleton loading page and update dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <ReportAnalyzer>true</ReportAnalyzer>
     <TargetFramework>net9.0</TargetFramework>
-    <VersionPrefix>0.12.2</VersionPrefix>
+    <VersionPrefix>0.12.3</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Tests/Innovative.Blazor.Components.Tests/GridTests.cs
+++ b/Tests/Innovative.Blazor.Components.Tests/GridTests.cs
@@ -25,7 +25,7 @@ namespace Innovative.Blazor.Components.Tests;
 /// </summary>
 public class GridTests : LocalizedTestBase
 {
-    private readonly Mock<ILogger<Components.InnovativeGrid<TestModel>>> _loggerMock;
+    private readonly Mock<ILogger<InnovativeGrid<TestModel>>> _loggerMock;
 
     /// <summary>
     ///     Setup common testing infrastructure for all grid tests.
@@ -33,7 +33,7 @@ public class GridTests : LocalizedTestBase
     public GridTests()
     {
         // Setup mocks for logging
-        _loggerMock = new Mock<ILogger<Components.InnovativeGrid<TestModel>>>();
+        _loggerMock = new Mock<ILogger<InnovativeGrid<TestModel>>>();
 
         // Register services
         Services.AddSingleton(_loggerMock.Object);
@@ -89,8 +89,8 @@ public class GridTests : LocalizedTestBase
         var cut = RenderGridComponent(testData, isLoading: true);
 
         // Assert
-        Contains("""<circle class="innovative-progressbar-circular-background" r="15.91549" fill="none""",
-            cut.Markup, StringComparison.Ordinal);
+        // Show the actual markup for debugging
+        cut.Markup.Should().Contain("rz-skeleton");
     }
 
     /// <summary>
@@ -124,25 +124,25 @@ public class GridTests : LocalizedTestBase
     {
         // Arrange
         var testData = new List<TestModel>
-        {
-            new()
-            {
-                TestProperty = "Test1",
-                CustomProperty = "CustomValue"
-            }
-        };
+                       {
+                           new()
+                           {
+                               TestProperty = "Test1"
+                             , CustomProperty = "CustomValue"
+                           }
+                       };
 
         // Act
         var cut = RenderGridComponent(testData);
 
         // Assert
         await cut.InvokeAsync(() =>
-        {
-            var markup = cut.Markup;
-            Contains("CustomValue", markup, StringComparison.Ordinal);
-            Contains("test", markup, StringComparison.Ordinal);
-            return Task.CompletedTask;
-        });
+                              {
+                                  var markup = cut.Markup;
+                                  Contains("CustomValue", markup, StringComparison.Ordinal);
+                                  Contains("test", markup, StringComparison.Ordinal);
+                                  return Task.CompletedTask;
+                              });
     }
 
     #endregion
@@ -160,23 +160,28 @@ public class GridTests : LocalizedTestBase
         var selectedItems = new List<TestModel>();
 
         // Act
-        var cut = RenderGridComponent(
-            testData,
-            enableRowSelection: true,
-            selectionMode: DataGridSelectionMode.Single,
-            onSelectionChanged: items => { selectedItems = items.ToList(); }
-        );
+        var cut = RenderGridComponent(testData
+                                    , enableRowSelection: true
+                                    , selectionMode: DataGridSelectionMode.Single
+                                    , onSelectionChanged: items =>
+                                                          {
+                                                              selectedItems = items.ToList();
+                                                          });
 
         // Assert
         await cut.InvokeAsync(async () =>
-        {
-            var gridInstance = cut.Instance;
-            await gridInstance.SetSelectedItemsAsync(new List<TestModel> { testData.First() }).ConfigureAwait(false);
-            await gridInstance.ReloadAsync().ConfigureAwait(false);
+                              {
+                                  var gridInstance = cut.Instance;
+                                  await gridInstance.SetSelectedItemsAsync(new List<TestModel>
+                                                                           {
+                                                                               testData.First()
+                                                                           })
+                                                    .ConfigureAwait(false);
+                                  await gridInstance.ReloadAsync().ConfigureAwait(false);
 
-            Single(selectedItems);
-            Equal("TestValue1", selectedItems.First().TestProperty);
-        });
+                                  Single(selectedItems);
+                                  Equal("TestValue1", selectedItems.First().TestProperty);
+                              });
     }
 
     /// <summary>
@@ -191,15 +196,19 @@ public class GridTests : LocalizedTestBase
 
         // Act & Assert
         await cut.InvokeAsync(async () =>
-        {
-            var gridInstance = cut.Instance;
-            await gridInstance.SetSelectedItemsAsync(new List<TestModel> { testData.First() }).ConfigureAwait(false);
+                              {
+                                  var gridInstance = cut.Instance;
+                                  await gridInstance.SetSelectedItemsAsync(new List<TestModel>
+                                                                           {
+                                                                               testData.First()
+                                                                           })
+                                                    .ConfigureAwait(false);
 
-            gridInstance.ClearSelection();
+                                  gridInstance.ClearSelection();
 
-            Empty(gridInstance.SelectedItems);
-            return Task.CompletedTask;
-        });
+                                  Empty(gridInstance.SelectedItems);
+                                  return Task.CompletedTask;
+                              });
     }
 
     #endregion
@@ -218,20 +227,18 @@ public class GridTests : LocalizedTestBase
 
         // Act & Assert
         await cut.InvokeAsync(async () =>
-        {
-            var gridInstance = cut.Instance;
-            await gridInstance.ApplyFilter("TestProperty", "TestValue1", FilterOperator.Equals).ConfigureAwait(false);
+                              {
+                                  var gridInstance = cut.Instance;
+                                  await gridInstance.ApplyFilter("TestProperty", "TestValue1", FilterOperator.Equals).ConfigureAwait(false);
 
-            // No warning should be logged
-            _loggerMock.Verify(
-                x => x.Log(
-                    It.IsAny<LogLevel>(),
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("not found")),
-                    It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()!),
-                Times.Never);
-        });
+                                  // No warning should be logged
+                                  _loggerMock.Verify(x => x.Log(It.IsAny<LogLevel>()
+                                                              , It.IsAny<EventId>()
+                                                              , It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("not found"))
+                                                              , It.IsAny<Exception>()
+                                                              , It.IsAny<Func<It.IsAnyType, Exception, string>>()!)
+                                                   , Times.Never);
+                              });
     }
 
     /// <summary>
@@ -245,13 +252,9 @@ public class GridTests : LocalizedTestBase
         var filterColumnName = "TestProperty";
         var filterValue = "TestValue";
         var operators = new[]
-        {
-            FilterOperator.Contains,
-            FilterOperator.StartsWith,
-            FilterOperator.EndsWith,
-            FilterOperator.GreaterThan,
-            FilterOperator.LessThan
-        };
+                        {
+                            FilterOperator.Contains, FilterOperator.StartsWith, FilterOperator.EndsWith, FilterOperator.GreaterThan, FilterOperator.LessThan
+                        };
 
         // Test each operator
         foreach (var op in operators)
@@ -262,20 +265,13 @@ public class GridTests : LocalizedTestBase
 
             // Act
             await cut.InvokeAsync(async () =>
-            {
-                var gridInstance = cut.Instance;
-                await gridInstance.ApplyFilter(filterColumnName, filterValue, op).ConfigureAwait(false);
-            });
+                                  {
+                                      var gridInstance = cut.Instance;
+                                      await gridInstance.ApplyFilter(filterColumnName, filterValue, op).ConfigureAwait(false);
+                                  });
 
             // Assert - No warnings should be logged
-            _loggerMock.Verify(
-                x => x.Log(
-                    LogLevel.Warning,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("not found")),
-                    It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()!),
-                Times.Never);
+            _loggerMock.Verify(x => x.Log(LogLevel.Warning, It.IsAny<EventId>(), It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("not found")), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Never);
         }
     }
 
@@ -295,19 +291,17 @@ public class GridTests : LocalizedTestBase
 
         // Act
         await cut.InvokeAsync(async () =>
-        {
-            await cut.Instance.ApplyFilter(invalidColumnName, "Value", FilterOperator.Equals).ConfigureAwait(false);
-        });
+                              {
+                                  await cut.Instance.ApplyFilter(invalidColumnName, "Value", FilterOperator.Equals).ConfigureAwait(false);
+                              });
 
         // Assert - Warning should be logged
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains($"Column {invalidColumnName} not found")),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()!),
-            Times.Once);
+        _loggerMock.Verify(x => x.Log(LogLevel.Warning
+                                    , It.IsAny<EventId>()
+                                    , It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains($"Column {invalidColumnName} not found"))
+                                    , It.IsAny<Exception>()
+                                    , It.IsAny<Func<It.IsAnyType, Exception, string>>()!)
+                         , Times.Once);
     }
 
     /// <summary>
@@ -324,17 +318,13 @@ public class GridTests : LocalizedTestBase
         _loggerMock.Reset();
 
         // Act
-        await cut.InvokeAsync(async () => { await cut.Instance.ClearFilter().ConfigureAwait(false); });
+        await cut.InvokeAsync(async () =>
+                              {
+                                  await cut.Instance.ClearFilter().ConfigureAwait(false);
+                              });
 
         // Assert - No warnings should be logged
-        _loggerMock.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.IsAny<It.IsAnyType>(),
-                It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()!),
-            Times.Never);
+        _loggerMock.Verify(x => x.Log(LogLevel.Warning, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Never);
     }
 
     #endregion
@@ -349,18 +339,17 @@ public class GridTests : LocalizedTestBase
     {
         // Arrange
         var testData = new List<TestModelWithMixedAttributes>
-        {
-            new TestModelWithMixedAttributes
-            {
-                PropertyWithAttribute = "WithAttribute",
-                PropertyWithoutAttribute = "NoAttribute"
-            }
-        };
+                       {
+                           new TestModelWithMixedAttributes
+                           {
+                               PropertyWithAttribute = "WithAttribute"
+                             , PropertyWithoutAttribute = "NoAttribute"
+                           }
+                       };
 
         // Act
-        var cut = RenderComponent<Components.InnovativeGrid<TestModelWithMixedAttributes>>(parameters => parameters
-                                                                                               .Add(p => p.Data, testData)
-                                                                                          );
+        var cut = RenderComponent<InnovativeGrid<TestModelWithMixedAttributes>>(parameters => parameters
+                                                                                    .Add(p => p.Data, testData));
 
         // Assert
         var markup = cut.Markup;
@@ -376,15 +365,22 @@ public class GridTests : LocalizedTestBase
     {
         // Arrange
         var testData = new List<TestModelWithGridClass>
-        {
-            new TestModelWithGridClass { TestProperty = "Value1", AnotherProperty = "Another1" },
-            new TestModelWithGridClass { TestProperty = "Value2", AnotherProperty = "Another2" }
-        };
+                       {
+                           new TestModelWithGridClass
+                           {
+                               TestProperty = "Value1"
+                             , AnotherProperty = "Another1"
+                           }
+                         , new TestModelWithGridClass
+                           {
+                               TestProperty = "Value2"
+                             , AnotherProperty = "Another2"
+                           }
+                       };
 
         // Act
-        var cut = RenderComponent<Components.InnovativeGrid<TestModelWithGridClass>>(parameters => parameters
-                                                                                         .Add(p => p.Data, testData)
-                                                                                    );
+        var cut = RenderComponent<InnovativeGrid<TestModelWithGridClass>>(parameters => parameters
+                                                                              .Add(p => p.Data, testData));
 
         // Assert - Ensure no sortable columns when AllowSorting is false
         var markup = cut.Markup;
@@ -399,14 +395,16 @@ public class GridTests : LocalizedTestBase
     {
         // Arrange
         var testData = new List<TestModelWithGridClass>
-        {
-            new TestModelWithGridClass { TestProperty = "Value1" }
-        };
+                       {
+                           new TestModelWithGridClass
+                           {
+                               TestProperty = "Value1"
+                           }
+                       };
 
         // Act
-        var cut = RenderComponent<Components.InnovativeGrid<TestModelWithGridClass>>(parameters => parameters
-                                                                                         .Add(p => p.Data, testData)
-                                                                                    );
+        var cut = RenderComponent<InnovativeGrid<TestModelWithGridClass>>(parameters => parameters
+                                                                              .Add(p => p.Data, testData));
 
         // Assert - Verify that localizer factory used the correct resource type
         LocalizerFactoryMock.Verify(f => f.Create(typeof(TestResources)), Times.Once);
@@ -443,8 +441,14 @@ public class GridTests : LocalizedTestBase
     {
         return
         [
-            new TestModel {TestProperty = "TestValue1"},
-            new TestModel {TestProperty = "TestValue2"}
+            new TestModel
+            {
+                TestProperty = "TestValue1"
+            }
+          , new TestModel
+            {
+                TestProperty = "TestValue2"
+            }
         ];
     }
 
@@ -453,37 +457,39 @@ public class GridTests : LocalizedTestBase
     /// </summary>
     private IRenderedComponent<InnovativeGrid<TestModel>> RenderGridComponent
     (
-        IEnumerable<TestModel> data,
-        string? title = null,
-        bool isLoading = false,
-        bool enableRowSelection = false,
-        DataGridSelectionMode selectionMode = DataGridSelectionMode.Single,
-        Action<IEnumerable<TestModel>>? onSelectionChanged = null,
-        GridHeight minHeightOption = GridHeight.Minimal)
+        IEnumerable<TestModel> data
+      , string? title = null
+      , bool isLoading = false
+      , bool enableRowSelection = false
+      , DataGridSelectionMode selectionMode = DataGridSelectionMode.Single
+      , Action<IEnumerable<TestModel>>? onSelectionChanged = null
+      , GridHeight minHeightOption = GridHeight.Minimal
+    )
     {
         return RenderComponent<InnovativeGrid<TestModel>>(parameters =>
-                                                         {
-                                                             parameters.Add(p => p.Data, data);
+                                                          {
+                                                              parameters.Add(p => p.Data, data);
 
-                                                             if (title != null)
-                                                                 parameters.Add(p => p.Title, title);
+                                                              if (title != null)
+                                                                  parameters.Add(p => p.Title, title);
 
-                                                             if (isLoading)
-                                                                 parameters.Add(p => p.IsLoading, true);
+                                                              if (isLoading)
+                                                                  parameters.Add(p => p.IsLoading, true);
 
-                                                             if (enableRowSelection)
-                                                                 parameters.Add(p => p.EnableRowSelection, true);
+                                                              if (enableRowSelection)
+                                                                  parameters.Add(p => p.EnableRowSelection, true);
 
-                                                             parameters.Add(p => p.SelectionMode, selectionMode);
+                                                              parameters.Add(p => p.SelectionMode, selectionMode);
 
-                                                             if (onSelectionChanged != null)
-                                                                 parameters.Add<IEnumerable<TestModel>>(p => p.OnSelectionChanged, onSelectionChanged);
+                                                              if (onSelectionChanged != null)
+                                                                  parameters.Add<IEnumerable<TestModel>>(p => p.OnSelectionChanged, onSelectionChanged);
 
-                                                             parameters.Add(p => p.MinHeightOption, minHeightOption);
-                                                         });
+                                                              parameters.Add(p => p.MinHeightOption, minHeightOption);
+                                                          });
     }
 
     #endregion
+
 }
 
 /// <summary>
@@ -491,9 +497,11 @@ public class GridTests : LocalizedTestBase
 /// </summary>
 internal sealed class TestCustomComponent : ComponentBase
 {
-    [Parameter] public string? Value { get; set; }
+    [Parameter]
+    public string? Value { get; set; }
 
-    [Parameter] public string? CustomParam { get; set; }
+    [Parameter]
+    public string? CustomParam { get; set; }
 
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {


### PR DESCRIPTION
```markdown
### Description

This pull request includes the following changes:

- Introduced a new `SampleGridLoading.razor` page, showcasing skeleton loading for the InnovativeGrid demo.
- Added `ExampleDataItem` model to support demonstration use cases.
- Updated `Radzen.Blazor` library to version 7.3.3.
- Upgraded FluentAssertions in tests for improved markup validation.
- Version updated in `Directory.Build.props` to 0.12.2.

### Checklist

- [ ] Code includes tests for new functionality, or tests are not needed.
- [ ] Documentation has been updated for changes in this PR, or documentation changes are not required.
- [ ] Changes follow project coding style and guidelines.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.12.3.

* **Tests**
  * Updated grid component tests to align with renamed component usage.
  * Added rendering support in a test component to enable explicit render logic.
  * Adjusted loading indicator assertion to validate skeleton-based markup.
  * Performed minor test cleanup and formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->