### PR TITLE
develop-add-skeleton-grid

### DIFF
--- a/ExampleApp/Pages/SampleGridLoading.razor
+++ b/ExampleApp/Pages/SampleGridLoading.razor
@@ -11,6 +11,7 @@
                 EnableRowSelection="true"
                 SelectionMode="DataGridSelectionMode.Single"
                 FilterStyle="FilterStyle.Advanced"/>
+<RadzenButton ButtonStyle="ButtonStyle.Primary " Click="RestartLoading">Restart Loading</RadzenButton>
 
 @code {
     private List<ExampleDataItem>? Data;
@@ -26,14 +27,24 @@
     {
         if (firstRender)
         {
-            await Task.Delay(2000);
-            Data = ExampleDataItem.GetExampleData().ToList();
-            //       IsLoading = false;
-            StateHasChanged();
+            await StartLoadingDelay();
         }
-
         await base.OnAfterRenderAsync(firstRender);
     }
 
-}
+    private async Task StartLoadingDelay()
+    {
+        IsLoading = true;
+        Data = null;
+        StateHasChanged();
+        await Task.Delay(3000);
+        Data = ExampleDataItem.GetExampleData().ToList();
+        IsLoading = false;
+        StateHasChanged();
+    }
 
+    private async Task RestartLoading()
+    {
+        await StartLoadingDelay();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Restart Loading button to the Sample Grid page, letting you manually retrigger the loading cycle. When used, the grid clears, shows a loading state for about 3 seconds, then repopulates with data, matching the initial page load behavior. This enables easy demoing or verification of loading states on demand without refreshing. Initial load behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->