### PR TITLE
Update version and add read-only field support in forms

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <ReportAnalyzer>true</ReportAnalyzer>
     <TargetFramework>net9.0</TargetFramework>
-    <VersionPrefix>0.12.3</VersionPrefix>
+    <VersionPrefix>0.13.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/ExampleApp/Pages/ExampleDialogService1.razor
+++ b/ExampleApp/Pages/ExampleDialogService1.razor
@@ -2,6 +2,8 @@
 
 <h3>Dialog Example 1</h3>
 
+
+
 <RadzenButton Text="Open Dialog" Click="@OpenPersonDialog" ButtonStyle="ButtonStyle.Primary" />
 
 <div class="mt-4">
@@ -12,4 +14,70 @@
             <li class="list-group-item">@logEntry</li>
         }
     </ul>
+</div>
+
+@* --- Example Explanation --- *@
+<div class="alert alert-info">
+    <strong>Example: Dialog Service with InnovativeForm</strong><br/>
+    This page demonstrates how to use the <code>InnovativeForm</code> component with the dialog service.<br/>
+    <ul>
+        <li>Click <b>Open Dialog</b> to launch a dialog containing a form generated from a model with <code>[UIFormField]</code>
+            attributes.
+        </li>
+        <li>Fields marked with <code>ReadOnly = true</code> in <code>[UIFormField]</code> will appear as read-only in
+            the form, regardless of property setters.
+        </li>
+        <li>Other <code>UIFormField</code> options (such as <code>UseWysiwyg</code>, <code>FormComponent</code>, <code>ColumnGroup</code>,
+            etc.) can be demonstrated by modifying the model.
+        </li>
+        <li>Actions taken in the dialog (e.g., Save, Cancel) are logged below.</li>
+    </ul>
+    <small>See the source code for more details on <code>UIFormField</code> behavior and customization.</small>
+</div>
+
+@* --- UIFormField and FormModel Usage Explanation --- *@
+<div class="alert alert-secondary mt-3">
+    <strong>About <code>[UIFormField]</code> and <code>FormModel</code> Usage</strong>
+    <p>
+        <code>[UIFormField]</code> is an attribute you place on model properties to control how they are rendered in <b>InnovativeForm</b>.<br/>
+        <b>Key properties include:</b>
+    </p>
+    <ul>
+        <li><b>ReadOnly</b>: If <code>true</code>, the field is always rendered as read-only, regardless of property
+            setters.
+        </li>
+        <li><b>UseWysiwyg</b>: If <code>true</code> and the property is a string, renders a WYSIWYG HTML editor.</li>
+        <li><b>FormComponent</b>: Specify a custom component for editing this field (must inherit <code>CustomComponent&lt;T&gt;</code>).
+        </li>
+        <li><b>DisplayComponent</b>: Specify a custom component for displaying this field in read-only mode.</li>
+        <li><b>ColumnGroup</b>: Group fields together for layout purposes.</li>
+        <li><b>FormParameters</b> / <b>DisplayParameters</b>: Pass extra parameters to the form or display component.
+        </li>
+        <li><b>TextProperty</b>: For complex types, which property to use as display text.</li>
+        <li><b>DataTestId</b>: Adds a <code>data-test-id</code> attribute for testing.</li>
+        <li><b>ShouldNotifyChanges</b>: If <code>true</code>, notifies the model of value changes (for advanced
+            scenarios).
+        </li>
+    </ul>
+    <p>
+        <code>FormModel</code> is a base class for your form models. It provides:
+    </p>
+    <ul>
+        <li>Exception handling and validation support (see <code>Exceptions</code> property).</li>
+        <li>Column layout support via <code>AddViewColumn</code> and <code>Columns</code>.</li>
+        <li>Integration with <code>InnovativeForm</code> for advanced scenarios (e.g., custom actions, change tracking).
+        </li>
+    </ul>
+    <p>
+        <b>Custom Components:</b> To use a custom component for a field, set <code>FormComponent</code> or <code>DisplayComponent</code>
+        to your component type. Your component should inherit from <code>CustomComponent&lt;T&gt;</code> and will
+        receive the value and change events automatically.
+    </p>
+    <p>
+        <b>Example usage:</b>
+    <pre><code>[UIFormField("Full Name", ReadOnly = true, FormComponent = typeof(FullNamePreviewComponent))]
+public string FullName { get; set; }</code></pre>
+    <p>
+        For more, see the <code>UIFormField</code> source code and the documentation.
+    </p>
 </div>

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
@@ -391,7 +391,7 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
         // Init-only setters have a metadata token with IsInitOnly flag
         // Reflection does not expose this directly, so we check for 'init' via metadata
         // This works in .NET 5+ (C# 9+)
-        if (setMethod.ReturnParameter.GetRequiredCustomModifiers().Any(m => m.Name == "IsExternalInit"))
+        if (setMethod.ReturnParameter.GetRequiredCustomModifiers().Any(m => m.FullName == "System.Runtime.CompilerServices.IsExternalInit"))
             return true;
 
         return false;

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.cs
@@ -18,15 +18,6 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
     private readonly Dictionary<string, object?> formValues = new Dictionary<string, object?>();
     private readonly IInnovativeStringLocalizer localizer;
 
-    [Parameter] public required TModel Model { get; set; }
-
-    [CascadingParameter] public required SidePanelComponent<TModel>? ParentDialog { get; set; }
-
-    private IReadOnlyCollection<PropertyInfo> ungroupedProperties { get; set; } = new List<PropertyInfo>();
-
-    private IReadOnlyCollection<KeyValuePair<string, List<PropertyInfo>>> OrderedColumnGroups { get; set; } =
-        new List<KeyValuePair<string, List<PropertyInfo>>>();
-
     public InnovativeForm(IInnovativeStringLocalizerFactory localizerFactory)
     {
         Debug.Assert(localizerFactory != null, $"{nameof(localizerFactory)} is null!");
@@ -36,9 +27,47 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
         localizer = localizerFactory.Create(resourceType);
     }
 
+    [Parameter]
+    public required TModel Model { get; set; }
+
+    [CascadingParameter]
+    public required SidePanelComponent<TModel>? ParentDialog { get; set; }
+
+    private IReadOnlyCollection<PropertyInfo> ungroupedProperties { get; set; } = new List<PropertyInfo>();
+
+    private IReadOnlyCollection<KeyValuePair<string, List<PropertyInfo>>> OrderedColumnGroups { get; set; } =
+        new List<KeyValuePair<string, List<PropertyInfo>>>();
+
+    public Task OnFormSubmit()
+    {
+        // Do not write the form values back to the model if the model has exceptions
+        if (Model is FormModel model
+         && model.Exceptions.Any())
+            return Task.CompletedTask;
+
+        foreach (var entry in formValues)
+        {
+            var prop = typeof(TModel).GetProperty(name: entry.Key);
+            if (prop?.CanWrite ?? false)
+            {
+                prop.SetValue(obj: Model, value: entry.Value);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnFormReset()
+    {
+        ResetToOriginalValues();
+        ParentDialog?.CloseCustomDialog();
+        return Task.CompletedTask;
+    }
+
     protected override void OnParametersSet()
     {
-        if (ParentDialog != null && Model is FormModel model)
+        if (ParentDialog != null
+         && Model is FormModel model)
         {
             ParentDialog.SetFormComponent(this);
 
@@ -79,9 +108,7 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
         {
             OrderedColumnGroups = columnOrder
                                   .Where(columnGroup => groupedProperties.ContainsKey(columnGroup))
-                                  .Select(columnGroup => new KeyValuePair<string, List<PropertyInfo>>(
-                                                                                                      columnGroup,
-                                                                                                      groupedProperties[columnGroup]))
+                                  .Select(columnGroup => new KeyValuePair<string, List<PropertyInfo>>(columnGroup, groupedProperties[columnGroup]))
                                   .Concat(groupedProperties
                                           .Where(g => !columnOrder.Contains(g.Key))
                                           .Select(g => g)!)
@@ -91,31 +118,6 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
         {
             OrderedColumnGroups = groupedProperties.ToList()!;
         }
-    }
-
-    public Task OnFormSubmit()
-    {
-        // Do not write the form values back to the model if the model has exceptions
-        if (Model is FormModel model && model.Exceptions.Any())
-            return Task.CompletedTask;
-
-        foreach (var entry in formValues)
-        {
-            var prop = typeof(TModel).GetProperty(name: entry.Key);
-            if (prop?.CanWrite ?? false)
-            {
-                prop.SetValue(obj: Model, value: entry.Value);
-            }
-        }
-
-        return Task.CompletedTask;
-    }
-
-    public Task OnFormReset()
-    {
-        ResetToOriginalValues();
-        ParentDialog?.CloseCustomDialog();
-        return Task.CompletedTask;
     }
 
     private void ResetToOriginalValues()
@@ -149,147 +151,157 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
 
     [ExcludeFromCodeCoverage]
     protected RenderFragment RenderPropertyField(PropertyInfo property) => builder =>
-    {
-        var fieldAttribute = property.GetCustomAttribute<UIFormField>();
-        bool notifyChanges = fieldAttribute?.ShouldNotifyChanges ?? false;
-        var propName = property.Name;
-        var isReadOnly = !property.CanWrite;
-        int sequence = 0;
+                                                                           {
+                                                                               var fieldAttribute = property.GetCustomAttribute<UIFormField>();
+                                                                               bool notifyChanges = fieldAttribute?.ShouldNotifyChanges ?? false;
+                                                                               var propName = property.Name;
+                                                                               var isReadOnly = IsReadOnly(property, fieldAttribute);
+                                                                               int sequence = 0;
 
-        if (ShouldShowLabel(fieldAttribute))
-        {
-            builder.OpenComponent<RadzenLabel>(sequence++);
-            builder.AddAttribute(sequence++, "Component", propName);
-            if (fieldAttribute?.Name != null)
-            {
-                builder.AddAttribute(sequence++, "Text", localizer.GetString(fieldAttribute.Name));
-            }
-            builder.CloseComponent();
-        }
+                                                                               if (ShouldShowLabel(fieldAttribute))
+                                                                               {
+                                                                                   builder.OpenComponent<RadzenLabel>(sequence++);
+                                                                                   builder.AddAttribute(sequence++, "Component", propName);
+                                                                                   if (fieldAttribute?.Name != null)
+                                                                                   {
+                                                                                       builder.AddAttribute(sequence++, "Text", localizer.GetString(fieldAttribute.Name));
+                                                                                   }
+                                                                                   builder.CloseComponent();
+                                                                               }
 
-        if (property.PropertyType == typeof(string))
-        {
-            var value = GetStringValue(propertyName: propName);
+                                                                               if (property.PropertyType == typeof(string))
+                                                                               {
+                                                                                   var value = GetStringValue(propertyName: propName);
 
-            if (fieldAttribute is { UseWysiwyg: true })
-            {
-                builder.OpenComponent<RadzenHtmlEditor>(sequence++);
-                builder.AddAttribute(sequence++, nameof(RadzenHtmlEditor.Name), propName);
-                builder.AddAttribute(sequence++, nameof(RadzenHtmlEditor.Value), value);
-                builder.AddAttribute(sequence++, nameof(RadzenHtmlEditor.ValueChanged),
-                                     EventCallback.Factory.Create<string>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
-                builder.AddAttribute(sequence++, nameof(RadzenHtmlEditor.Style), "height: max-content; min-height: 250px; max-height: 400px;");
+                                                                                   if (fieldAttribute is {UseWysiwyg: true})
+                                                                                   {
+                                                                                       builder.OpenComponent<RadzenHtmlEditor>(sequence++);
+                                                                                       builder.AddAttribute(sequence++, nameof(RadzenHtmlEditor.Name), propName);
+                                                                                       builder.AddAttribute(sequence++, nameof(RadzenHtmlEditor.Value), value);
+                                                                                       builder.AddAttribute(sequence++
+                                                                                                          , nameof(RadzenHtmlEditor.ValueChanged)
+                                                                                                          , EventCallback.Factory.Create<string>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
+                                                                                       builder.AddAttribute(sequence++, nameof(RadzenHtmlEditor.Style), "height: max-content; min-height: 250px; max-height: 400px;");
 
-                if (isReadOnly)
-                    builder.AddAttribute(sequence++, nameof(RadzenHtmlEditor.Disabled), true);
-                if (!string.IsNullOrEmpty(fieldAttribute.DataTestId))
-                    builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
+                                                                                       if (isReadOnly)
+                                                                                           builder.AddAttribute(sequence++, nameof(RadzenHtmlEditor.Disabled), true);
+                                                                                       if (!string.IsNullOrEmpty(fieldAttribute.DataTestId))
+                                                                                           builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
 
-                AppendFormParameters(builder, fieldAttribute.FormParameters, ref sequence);
-                builder.CloseComponent();
-            }
-            else
-            {
-                builder.OpenComponent<RadzenTextBox>(sequence++);
-                builder.AddAttribute(sequence++, "class", "w-100");
-                builder.AddComponentParameter(sequence++, nameof(RadzenTextBox.Name), propName);
-                builder.AddAttribute(sequence++, nameof(RadzenTextBox.Value), value);
-                builder.AddAttribute(sequence++, nameof(RadzenTextBox.ValueChanged),
-                                     EventCallback.Factory.Create<string>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
+                                                                                       AppendFormParameters(builder, fieldAttribute.FormParameters, ref sequence);
+                                                                                       builder.CloseComponent();
+                                                                                   }
+                                                                                   else
+                                                                                   {
+                                                                                       builder.OpenComponent<RadzenTextBox>(sequence++);
+                                                                                       builder.AddAttribute(sequence++, "class", "w-100");
+                                                                                       builder.AddComponentParameter(sequence++, nameof(RadzenTextBox.Name), propName);
+                                                                                       builder.AddAttribute(sequence++, nameof(RadzenTextBox.Value), value);
+                                                                                       builder.AddAttribute(sequence++
+                                                                                                          , nameof(RadzenTextBox.ValueChanged)
+                                                                                                          , EventCallback.Factory.Create<string>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
 
-                if (isReadOnly)
-                    builder.AddAttribute(sequence++, nameof(RadzenTextBox.Disabled), true);
-                if (!string.IsNullOrEmpty(fieldAttribute?.DataTestId))
-                    builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
+                                                                                       if (isReadOnly)
+                                                                                           builder.AddAttribute(sequence++, nameof(RadzenTextBox.Disabled), true);
+                                                                                       if (!string.IsNullOrEmpty(fieldAttribute?.DataTestId))
+                                                                                           builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
 
-                AppendFormParameters(builder, fieldAttribute?.FormParameters, ref sequence);
-                builder.CloseComponent();
-            }
-        }
-        else if (property.PropertyType == typeof(int) || property.PropertyType == typeof(int?))
-        {
-            var value = GetIntValue(propertyName: propName);
+                                                                                       AppendFormParameters(builder, fieldAttribute?.FormParameters, ref sequence);
+                                                                                       builder.CloseComponent();
+                                                                                   }
+                                                                               }
+                                                                               else if (property.PropertyType == typeof(int)
+                                                                                     || property.PropertyType == typeof(int?))
+                                                                               {
+                                                                                   var value = GetIntValue(propertyName: propName);
 
-            builder.OpenComponent(sequence++, typeof(RadzenNumeric<int?>));
-            builder.AddAttribute(sequence++, "class", "w-100");
-            builder.AddAttribute(sequence++, nameof(RadzenNumeric<int?>.Name), propName);
-            builder.AddAttribute(sequence++, nameof(RadzenNumeric<int?>.Value), value);
-            builder.AddAttribute(sequence++, nameof(RadzenNumeric<int?>.ValueChanged),
-                                 EventCallback.Factory.Create<int?>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
+                                                                                   builder.OpenComponent(sequence++, typeof(RadzenNumeric<int?>));
+                                                                                   builder.AddAttribute(sequence++, "class", "w-100");
+                                                                                   builder.AddAttribute(sequence++, nameof(RadzenNumeric<int?>.Name), propName);
+                                                                                   builder.AddAttribute(sequence++, nameof(RadzenNumeric<int?>.Value), value);
+                                                                                   builder.AddAttribute(sequence++
+                                                                                                      , nameof(RadzenNumeric<int?>.ValueChanged)
+                                                                                                      , EventCallback.Factory.Create<int?>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
 
+                                                                                   if (isReadOnly)
+                                                                                       builder.AddAttribute(sequence++, nameof(RadzenNumeric<int?>.Disabled), true);
+                                                                                   if (!string.IsNullOrEmpty(fieldAttribute?.DataTestId))
+                                                                                       builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
 
-            if (isReadOnly)
-                builder.AddAttribute(sequence++, nameof(RadzenNumeric<int?>.Disabled), true);
-            if (!string.IsNullOrEmpty(fieldAttribute?.DataTestId))
-                builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
+                                                                                   AppendFormParameters(builder, fieldAttribute?.FormParameters, ref sequence);
+                                                                                   builder.CloseComponent();
+                                                                               }
+                                                                               else if (property.PropertyType == typeof(decimal)
+                                                                                     || property.PropertyType == typeof(decimal?))
+                                                                               {
+                                                                                   var value = GetDecimalValue(propertyName: propName);
+                                                                                   builder.OpenComponent(sequence++, typeof(RadzenNumeric<decimal?>));
+                                                                                   builder.AddAttribute(sequence++, "class", "w-100");
+                                                                                   builder.AddAttribute(sequence++, nameof(RadzenNumeric<decimal?>.Name), propName);
+                                                                                   builder.AddAttribute(sequence++, nameof(RadzenNumeric<decimal?>.Value), value);
+                                                                                   builder.AddAttribute(sequence++, nameof(RadzenNumeric<decimal?>.Culture), CultureInfo.CurrentCulture);
+                                                                                   builder.AddAttribute(sequence++
+                                                                                                      , nameof(RadzenNumeric<decimal?>.ValueChanged)
+                                                                                                      , EventCallback.Factory.Create<decimal?>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
 
-            AppendFormParameters(builder, fieldAttribute?.FormParameters, ref sequence);
-            builder.CloseComponent();
-        }
-        else if (property.PropertyType == typeof(decimal) || property.PropertyType == typeof(decimal?))
-        {
-            var value = GetDecimalValue(propertyName: propName);
-            builder.OpenComponent(sequence++, typeof(RadzenNumeric<decimal?>));
-            builder.AddAttribute(sequence++, "class", "w-100");
-            builder.AddAttribute(sequence++, nameof(RadzenNumeric<decimal?>.Name), propName);
-            builder.AddAttribute(sequence++, nameof(RadzenNumeric<decimal?>.Value), value);
-            builder.AddAttribute(sequence++, nameof(RadzenNumeric<decimal?>.Culture), CultureInfo.CurrentCulture);
-            builder.AddAttribute(sequence++, nameof(RadzenNumeric<decimal?>.ValueChanged),
-                                 EventCallback.Factory.Create<decimal?>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
+                                                                                   if (isReadOnly)
+                                                                                       builder.AddAttribute(sequence++, nameof(RadzenNumeric<decimal?>.Disabled), true);
+                                                                                   if (!string.IsNullOrEmpty(fieldAttribute?.DataTestId))
+                                                                                       builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
 
-            if (isReadOnly)
-                builder.AddAttribute(sequence++, nameof(RadzenNumeric<decimal?>.Disabled), true);
-            if (!string.IsNullOrEmpty(fieldAttribute?.DataTestId))
-                builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
+                                                                                   AppendFormParameters(builder, fieldAttribute?.FormParameters, ref sequence);
+                                                                                   builder.CloseComponent();
+                                                                               }
+                                                                               else if (property.PropertyType == typeof(bool)
+                                                                                     || property.PropertyType == typeof(bool?))
+                                                                               {
+                                                                                   var value = GetBoolValue(propertyName: propName);
 
-            AppendFormParameters(builder, fieldAttribute?.FormParameters, ref sequence);
-            builder.CloseComponent();
-        }
-        else if (property.PropertyType == typeof(bool) || property.PropertyType == typeof(bool?))
-        {
-            var value = GetBoolValue(propertyName: propName);
+                                                                                   builder.OpenComponent(sequence++, typeof(RadzenCheckBox<bool?>));
+                                                                                   builder.AddAttribute(sequence++, nameof(RadzenCheckBox<bool?>.Name), propName);
+                                                                                   builder.AddAttribute(sequence++, nameof(RadzenCheckBox<bool?>.Value), value);
+                                                                                   builder.AddAttribute(sequence++
+                                                                                                      , nameof(RadzenCheckBox<bool?>.ValueChanged)
+                                                                                                      , EventCallback.Factory.Create<bool?>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
 
-            builder.OpenComponent(sequence++, typeof(RadzenCheckBox<bool?>));
-            builder.AddAttribute(sequence++, nameof(RadzenCheckBox<bool?>.Name), propName);
-            builder.AddAttribute(sequence++, nameof(RadzenCheckBox<bool?>.Value), value);
-            builder.AddAttribute(sequence++, nameof(RadzenCheckBox<bool?>.ValueChanged),
-                                 EventCallback.Factory.Create<bool?>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
+                                                                                   if (isReadOnly)
+                                                                                       builder.AddAttribute(sequence++, nameof(RadzenCheckBox<bool?>.Disabled), true);
+                                                                                   if (!string.IsNullOrEmpty(fieldAttribute?.DataTestId))
+                                                                                       builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
 
-            if (isReadOnly)
-                builder.AddAttribute(sequence++, nameof(RadzenCheckBox<bool?>.Disabled), true);
-            if (!string.IsNullOrEmpty(fieldAttribute?.DataTestId))
-                builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
+                                                                                   AppendFormParameters(builder, fieldAttribute?.FormParameters, ref sequence);
+                                                                                   builder.CloseComponent();
+                                                                               }
+                                                                               else if (property.PropertyType == typeof(DateTime)
+                                                                                     || property.PropertyType == typeof(DateTime?))
+                                                                               {
+                                                                                   var value = GetDateTimeValue(propertyName: propName);
 
-            AppendFormParameters(builder, fieldAttribute?.FormParameters, ref sequence);
-            builder.CloseComponent();
-        }
-        else if (property.PropertyType == typeof(DateTime) || property.PropertyType == typeof(DateTime?))
-        {
-            var value = GetDateTimeValue(propertyName: propName);
+                                                                                   builder.OpenComponent(sequence++, typeof(RadzenDatePicker<DateTime?>));
+                                                                                   builder.AddAttribute(sequence++, "class", "w-100");
+                                                                                   builder.AddAttribute(sequence++, nameof(RadzenDatePicker<DateTime?>.Name), propName);
+                                                                                   builder.AddAttribute(sequence++, nameof(RadzenDatePicker<DateTime?>.Value), value);
+                                                                                   builder.AddAttribute(sequence++
+                                                                                                      , nameof(RadzenDatePicker<DateTime?>.ValueChanged)
+                                                                                                      , EventCallback.Factory.Create<DateTime?>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
 
-            builder.OpenComponent(sequence++, typeof(RadzenDatePicker<DateTime?>));
-            builder.AddAttribute(sequence++, "class", "w-100");
-            builder.AddAttribute(sequence++, nameof(RadzenDatePicker<DateTime?>.Name), propName);
-            builder.AddAttribute(sequence++, nameof(RadzenDatePicker<DateTime?>.Value), value);
-            builder.AddAttribute(sequence++, nameof(RadzenDatePicker<DateTime?>.ValueChanged),
-                                 EventCallback.Factory.Create<DateTime?>(this, val => SetValue(propertyName: propName, value: val, notifyChanges)));
+                                                                                   if (isReadOnly)
+                                                                                       builder.AddAttribute(sequence++, nameof(RadzenDatePicker<DateTime?>.Disabled), true);
+                                                                                   if (!string.IsNullOrEmpty(fieldAttribute?.DataTestId))
+                                                                                       builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
 
-            if (isReadOnly)
-                builder.AddAttribute(sequence++, nameof(RadzenDatePicker<DateTime?>.Disabled), true);
-            if (!string.IsNullOrEmpty(fieldAttribute?.DataTestId))
-                builder.AddAttribute(sequence++, DataTestIdKey, fieldAttribute.DataTestId);
-
-            AppendFormParameters(builder, fieldAttribute?.FormParameters, ref sequence);
-            builder.CloseComponent();
-        }
-    };
+                                                                                   AppendFormParameters(builder, fieldAttribute?.FormParameters, ref sequence);
+                                                                                   builder.CloseComponent();
+                                                                               }
+                                                                           };
 
     private static void AppendFormParameters(RenderTreeBuilder builder, string[]? formParameters, ref int sequence)
     {
         foreach (string parameter in formParameters ?? [])
         {
             int equalIndex = parameter.IndexOf('=', StringComparison.InvariantCultureIgnoreCase);
-            if (equalIndex > 0 && equalIndex < parameter.Length - 1)
+            if (equalIndex > 0
+             && equalIndex < parameter.Length - 1)
             {
                 string paramName = parameter[..equalIndex];
                 string paramValue = parameter[++equalIndex..];
@@ -319,43 +331,70 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
     private RenderFragment RenderFormComponent(object? value, UIFormField attribute, PropertyInfo property)
     {
         var propName = property.Name;
+        var isReadOnly = IsReadOnly(property, attribute);
         return builder =>
-        {
-            try
-            {
-                if (attribute.FormComponent == null)
-                {
-                    return;
-                }
-                int sequence = 0;
+               {
+                   try
+                   {
+                       if (attribute.FormComponent == null)
+                       {
+                           return;
+                       }
+                       int sequence = 0;
 
-                if (ShouldShowLabel(attribute))
-                {
-                    // Add label for component
-                    builder.OpenComponent<RadzenLabel>(sequence++);
-                    builder.AddAttribute(sequence++, "Component", attribute.Name);
-                    builder.AddAttribute(sequence, "Text", localizer.GetString(attribute.Name));
-                    builder.CloseComponent();
-                }
+                       if (ShouldShowLabel(attribute))
+                       {
+                           // Add label for component
+                           builder.OpenComponent<RadzenLabel>(sequence++);
+                           builder.AddAttribute(sequence++, "Component", attribute.Name);
+                           builder.AddAttribute(sequence, "Text", localizer.GetString(attribute.Name));
+                           builder.CloseComponent();
+                       }
 
-                // Add custom component
-                sequence = 0;
-                builder.OpenComponent(sequence: sequence++, componentType: attribute.FormComponent);
-                builder.AddAttribute(sequence: sequence++, name: "Value", value: value);
-                builder.AddAttribute(sequence++, "ValueChanged", EventCallback.Factory.Create(this, val =>
-                                                                                                        SetValue(propertyName: propName, value: val, attribute.ShouldNotifyChanges)));
+                       // Add custom component
+                       sequence = 0;
+                       builder.OpenComponent(sequence: sequence++, componentType: attribute.FormComponent);
+                       builder.AddAttribute(sequence: sequence++, name: "Value", value: value);
+                       builder.AddAttribute(sequence++
+                                          , "ValueChanged"
+                                          , EventCallback.Factory.Create(this
+                                                                       , val =>
+                                                                             SetValue(propertyName: propName, value: val, attribute.ShouldNotifyChanges)));
 
-                if (!string.IsNullOrEmpty(attribute?.DataTestId))
-                    builder.AddAttribute(sequence++, nameof(attribute.DataTestId), attribute.DataTestId);
+                       if (isReadOnly)
+                           builder.AddAttribute(sequence++, "Disabled", true);
+                       if (!string.IsNullOrEmpty(attribute?.DataTestId))
+                           builder.AddAttribute(sequence++, nameof(attribute.DataTestId), attribute.DataTestId);
 
-                AppendFormParameters(builder, attribute?.FormParameters, ref sequence);
-                builder.CloseComponent();
-            }
-            catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
-            {
-                builder.AddMarkupContent(sequence: 0, markupContent: $"<span class=\"text-danger\">Error: {ex.Message}</span>");
-            }
-        };
+                       AppendFormParameters(builder, attribute?.FormParameters, ref sequence);
+                       builder.CloseComponent();
+                   }
+                   catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+                   {
+                       builder.AddMarkupContent(sequence: 0, markupContent: $"<span class=\"text-danger\">Error: {ex.Message}</span>");
+                   }
+               };
+    }
+
+    private static bool IsReadOnly(PropertyInfo property, UIFormField? fieldAttribute)
+    {
+        // If UIFormField.ReadOnly is set, always treat as read-only
+        if (fieldAttribute?.ReadOnly == true)
+            return true;
+
+        // If property has no setter, treat as read-only
+        var setMethod = property.SetMethod;
+        if (setMethod == null)
+            return true;
+
+        // If setter is init-only (C# 9+), treat as read-only
+        // Init-only setters have a metadata token with IsInitOnly flag
+        // Reflection does not expose this directly, so we check for 'init' via metadata
+        // This works in .NET 5+ (C# 9+)
+        if (setMethod.ReturnParameter.GetRequiredCustomModifiers().Any(m => m.Name == "IsExternalInit"))
+            return true;
+
+        return false;
     }
 
     private string GetStringValue(string propertyName)
@@ -370,7 +409,8 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
 
     private int? GetIntValue(string propertyName)
     {
-        if (formValues.TryGetValue(key: propertyName, value: out var value) && value != null)
+        if (formValues.TryGetValue(key: propertyName, value: out var value)
+         && value != null)
         {
             return Convert.ToInt32(value: value, CultureInfo.InvariantCulture);
         }
@@ -380,7 +420,8 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
 
     private decimal? GetDecimalValue(string propertyName)
     {
-        if (formValues.TryGetValue(key: propertyName, value: out var value) && value != null)
+        if (formValues.TryGetValue(key: propertyName, value: out var value)
+         && value != null)
         {
             return Convert.ToDecimal(value: value, CultureInfo.InvariantCulture);
         }
@@ -390,7 +431,8 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
 
     private bool? GetBoolValue(string propertyName)
     {
-        if (formValues.TryGetValue(key: propertyName, value: out var value) && value != null)
+        if (formValues.TryGetValue(key: propertyName, value: out var value)
+         && value != null)
         {
             return Convert.ToBoolean(value: value, CultureInfo.InvariantCulture);
         }
@@ -400,7 +442,8 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
 
     private DateTime? GetDateTimeValue(string propertyName)
     {
-        if (formValues.TryGetValue(key: propertyName, value: out var value) && value != null)
+        if (formValues.TryGetValue(key: propertyName, value: out var value)
+         && value != null)
         {
             return Convert.ToDateTime(value: value, CultureInfo.InvariantCulture);
         }
@@ -436,8 +479,8 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
     private static PropertyInfo[] GetPropertiesWithUiFormField()
     {
         return typeof(TModel).GetProperties()
-            .Where(predicate: p => p.GetCustomAttribute<UIFormField>() != null)
-            .ToArray();
+                             .Where(predicate: p => p.GetCustomAttribute<UIFormField>() != null)
+                             .ToArray();
     }
 
     private static bool ShouldShowLabel(UIFormField? formField)
@@ -466,8 +509,9 @@ public partial class InnovativeForm<TModel> : ComponentBase, IFormComponent
 
         LocalizedString displayName = localizer[name: property.GetCustomAttribute<UIFormField>()?.Name ?? propertyName];
         var context = new ValidationContext(instance: model)
-                      { MemberName = propertyName
-                      , DisplayName = displayName
+                      {
+                          MemberName = propertyName
+                        , DisplayName = displayName
                       };
         _ = Validator.TryValidateProperty(value: value, validationContext: context, validationResults: results);
 

--- a/Src/Innovative.Blazor.Components/Components/Form/UIFormField.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/UIFormField.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using Innovative.Blazor.Components.Attributes;
 
 namespace Innovative.Blazor.Components.Components;
@@ -8,27 +7,20 @@ namespace Innovative.Blazor.Components.Components;
 [AttributeUsage(validOn: AttributeTargets.Property)]
 public sealed class UIFormField(string name) : UIField(name)
 {
+
+    private Type? _displayComponent;
+
+    private Type? _formComponent;
     public string? ColumnGroup { get; set; }
     public bool UseWysiwyg { get; set; }
 
-    internal static bool InheritsFromGenericCustomComponent(Type? type)
-    {
-        while (type != null && type != typeof(object))
-        {
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(CustomComponent<>))
-                return true;
-            type = type.BaseType;
-        }
-        return false;
-    }
-
-    private Type? _displayComponent;
     public Type? DisplayComponent
     {
         get => _displayComponent;
         set
         {
-            if (value != null && !InheritsFromGenericCustomComponent(value))
+            if (value != null
+             && !InheritsFromGenericCustomComponent(value))
             {
                 throw new ArgumentException($"DisplayComponent must inherit from CustomComponent<T>, but got {value.FullName}");
             }
@@ -36,13 +28,13 @@ public sealed class UIFormField(string name) : UIField(name)
         }
     }
 
-    private Type? _formComponent;
     public Type? FormComponent
     {
         get => _formComponent;
         set
         {
-            if (value != null && !InheritsFromGenericCustomComponent(value))
+            if (value != null
+             && !InheritsFromGenericCustomComponent(value))
             {
                 throw new ArgumentException($"FormComponent must inherit from CustomComponent<T>, but got {value.FullName}");
             }
@@ -54,5 +46,22 @@ public sealed class UIFormField(string name) : UIField(name)
     public string[]? FormParameters { get; set; }
     public string? TextProperty { get; set; }
     public string DataTestId { get; set; } = string.Empty;
+
     public bool ShouldNotifyChanges { get; set; }
+
+    // If true, the field is displayed as read-only in the form.
+    public bool ReadOnly { get; set; }
+
+    internal static bool InheritsFromGenericCustomComponent(Type? type)
+    {
+        while (type != null
+            && type != typeof(object))
+        {
+            if (type.IsGenericType
+             && type.GetGenericTypeDefinition() == typeof(CustomComponent<>))
+                return true;
+            type = type.BaseType;
+        }
+        return false;
+    }
 }

--- a/Src/Innovative.Blazor.Components/Components/Form/UIFormField.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/UIFormField.cs
@@ -3,17 +3,32 @@ using Innovative.Blazor.Components.Attributes;
 
 namespace Innovative.Blazor.Components.Components;
 
+/// <summary>
+/// Attribute to mark a property as a form field for InnovativeForm. Controls rendering, grouping, component selection, and behavior.
+/// </summary>
+/// <param name="name">The display name or resource key for the field label.</param>
 [ExcludeFromCodeCoverage]
 [AttributeUsage(validOn: AttributeTargets.Property)]
 public sealed class UIFormField(string name) : UIField(name)
 {
-
     private Type? _displayComponent;
-
     private Type? _formComponent;
+
+    /// <summary>
+    /// The name of the column group this field belongs to. Used for grouping fields in the form layout.
+    /// </summary>
     public string? ColumnGroup { get; set; }
+
+    /// <summary>
+    /// If true, renders this field using a WYSIWYG HTML editor (RadzenHtmlEditor) instead of a standard textbox.
+    /// Only applies to string properties.
+    /// </summary>
     public bool UseWysiwyg { get; set; }
 
+    /// <summary>
+    /// The component type to use for displaying this field in read-only (display) mode.
+    /// Must inherit from CustomComponent&lt;T&gt;.
+    /// </summary>
     public Type? DisplayComponent
     {
         get => _displayComponent;
@@ -21,13 +36,15 @@ public sealed class UIFormField(string name) : UIField(name)
         {
             if (value != null
              && !InheritsFromGenericCustomComponent(value))
-            {
                 throw new ArgumentException($"DisplayComponent must inherit from CustomComponent<T>, but got {value.FullName}");
-            }
             _displayComponent = value;
         }
     }
 
+    /// <summary>
+    /// The component type to use for editing this field in the form.
+    /// Must inherit from CustomComponent&lt;T&gt;.
+    /// </summary>
     public Type? FormComponent
     {
         get => _formComponent;
@@ -35,23 +52,46 @@ public sealed class UIFormField(string name) : UIField(name)
         {
             if (value != null
              && !InheritsFromGenericCustomComponent(value))
-            {
                 throw new ArgumentException($"FormComponent must inherit from CustomComponent<T>, but got {value.FullName}");
-            }
             _formComponent = value;
         }
     }
 
+    /// <summary>
+    /// Parameters to pass to the display component (as name=value strings).
+    /// </summary>
     public string[]? DisplayParameters { get; set; }
+
+    /// <summary>
+    /// Parameters to pass to the form (edit) component (as name=value strings).
+    /// </summary>
     public string[]? FormParameters { get; set; }
+
+    /// <summary>
+    /// The name of the property to use for display text (for complex types or lookups).
+    /// </summary>
     public string? TextProperty { get; set; }
+
+    /// <summary>
+    /// The data-test-id attribute value for this field, used for automated testing.
+    /// </summary>
     public string DataTestId { get; set; } = string.Empty;
 
+    /// <summary>
+    /// If true, changes to this field will trigger change notifications (INotifyFormValueChanged).
+    /// </summary>
     public bool ShouldNotifyChanges { get; set; }
 
-    // If true, the field is displayed as read-only in the form.
+    /// <summary>
+    /// If true, the field is rendered as read-only in the form, regardless of property setter.
+    /// </summary>
     public bool ReadOnly { get; set; }
 
+    /// <summary>
+    /// Checks if a type inherits from CustomComponent&lt;T&gt; (generic base class).
+    /// </summary>
+    /// <param name="type">The type to check.</param>
+    /// <returns>True if the type inherits from CustomComponent&lt;T&gt;, otherwise false.</returns>
     internal static bool InheritsFromGenericCustomComponent(Type? type)
     {
         while (type != null

--- a/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
+++ b/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
@@ -74,7 +74,6 @@ public class InnovativeFormTests : LocalizedTestBase
                         {
                             Model = model
                           , ParentDialog = dialogMock.Object
-                           ,
                         };
 
         component.CallOnParametersSet();

--- a/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
+++ b/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
@@ -120,7 +120,6 @@ public class InnovativeFormTests : LocalizedTestBase
                         {
                             Model = actual
                           , ParentDialog = dialogMock.Object
-                           ,
                         };
 
         component.CallOnParametersSet();

--- a/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
+++ b/Tests/Innovative.Blazor.Components.Tests/InnovativeFormTests.cs
@@ -33,19 +33,19 @@ public class InnovativeFormTests : LocalizedTestBase
         const int allActions = saveFormAction + cancelFormAction + deleteFormAction + customAction;
 
         var model = new TestFormModel
-        {
-            StringProperty = "Test",
-            IntProperty = 42,
-            BoolProperty = true,
-            DateProperty = new DateTime(2023, 1, 1),
-            CustomAction = (x) => Debug.WriteLine(x)
-        };
+                    {
+                        StringProperty = "Test"
+                      , IntProperty = 42
+                      , BoolProperty = true
+                      , DateProperty = new DateTime(2023, 1, 1)
+                      , CustomAction = (x) => Debug.WriteLine(x)
+                    };
 
         var component = new InnovativeForm<TestFormModel>(LocalizerFactoryMock.Object)
-        {
-            Model = model,
-            ParentDialog = dialogMock.Object
-        };
+                        {
+                            Model = model
+                          , ParentDialog = dialogMock.Object
+                        };
 
         // Act
         component.CallOnParametersSet();
@@ -64,17 +64,18 @@ public class InnovativeFormTests : LocalizedTestBase
         // Arrange
         var model = new TestFormModel
                     {
-                        StringProperty = "Test",
-                        IntProperty = 42,
-                        BoolProperty = true,
-                        DateProperty = new DateTime(2023, 1, 1)
+                        StringProperty = "Test"
+                      , IntProperty = 42
+                      , BoolProperty = true
+                      , DateProperty = new DateTime(2023, 1, 1)
                     };
 
         var component = new InnovativeForm<TestFormModel>(LocalizerFactoryMock.Object)
-        {
-            Model = model,
-            ParentDialog = dialogMock.Object,
-        };
+                        {
+                            Model = model
+                          , ParentDialog = dialogMock.Object
+                           ,
+                        };
 
         component.CallOnParametersSet();
         component.SetFormValue(nameof(model.StringProperty), "Updated");
@@ -99,27 +100,28 @@ public class InnovativeFormTests : LocalizedTestBase
     {
         // Arrange
         var actual = new TestFormModel
-                    {
-                        StringProperty = "Test",
-                        IntProperty = 42,
-                        BoolProperty = true,
-                        DateProperty = new DateTime(2023, 1, 1),
-                        CustomAction = (x) => Debug.WriteLine(x)
-                    };
+                     {
+                         StringProperty = "Test"
+                       , IntProperty = 42
+                       , BoolProperty = true
+                       , DateProperty = new DateTime(2023, 1, 1)
+                       , CustomAction = (x) => Debug.WriteLine(x)
+                     };
 
         var expected = new TestFormModel
-                    {
-                        StringProperty = actual.StringProperty,
-                        IntProperty = actual.IntProperty,
-                        BoolProperty = actual.BoolProperty,
-                        DateProperty = actual.DateProperty,
-                        CustomAction = actual.CustomAction
-        };
+                       {
+                           StringProperty = actual.StringProperty
+                         , IntProperty = actual.IntProperty
+                         , BoolProperty = actual.BoolProperty
+                         , DateProperty = actual.DateProperty
+                         , CustomAction = actual.CustomAction
+                       };
 
         var component = new InnovativeForm<TestFormModel>(LocalizerFactoryMock.Object)
                         {
-                            Model = actual,
-                            ParentDialog = dialogMock.Object,
+                            Model = actual
+                          , ParentDialog = dialogMock.Object
+                           ,
                         };
 
         component.CallOnParametersSet();
@@ -146,10 +148,10 @@ public class InnovativeFormTests : LocalizedTestBase
     {
         // Arrange
         var component = new InnovativeForm<TestFormGroupModel>(LocalizerFactoryMock.Object)
-        {
-            Model = new TestFormGroupModel(),
-            ParentDialog = new Mock<SidePanelComponent<TestFormGroupModel>>(customDialogServiceMock.Object).Object
-        };
+                        {
+                            Model = new TestFormGroupModel()
+                          , ParentDialog = new Mock<SidePanelComponent<TestFormGroupModel>>(customDialogServiceMock.Object).Object
+                        };
 
         // Act
         component.CallOnParametersSet();
@@ -174,10 +176,10 @@ public class InnovativeFormTests : LocalizedTestBase
     {
         // Arrange
         var component = new InnovativeForm<TestFormColumnWidthModel>(LocalizerFactoryMock.Object)
-        {
-            Model = new TestFormColumnWidthModel(),
-            ParentDialog = new Mock<SidePanelComponent<TestFormColumnWidthModel>>(customDialogServiceMock.Object).Object
-        };
+                        {
+                            Model = new TestFormColumnWidthModel()
+                          , ParentDialog = new Mock<SidePanelComponent<TestFormColumnWidthModel>>(customDialogServiceMock.Object).Object
+                        };
 
         // Act
         var width1 = component.CallGetColumnWidthClass("Col1");
@@ -189,21 +191,77 @@ public class InnovativeFormTests : LocalizedTestBase
         Assert.Equal("", width2); // 0 width should return empty string
         Assert.Equal("", widthNonExistent);
     }
+
+    [Fact]
+    public void When_UIFormFieldReadOnly_ItShouldBeReadOnlyInForm()
+    {
+        // Arrange
+        var model = new TestFormReadOnlyModel
+                    {
+                        ReadOnlyString = "abc"
+                      , NormalString = "def"
+                    };
+        var component = new InnovativeForm<TestFormReadOnlyModel>(LocalizerFactoryMock.Object)
+                        {
+                            Model = model
+                          , ParentDialog = new Mock<SidePanelComponent<TestFormReadOnlyModel>>(customDialogServiceMock.Object).Object
+                        };
+        component.CallOnParametersSet();
+
+        // Use reflection to get IsReadOnly method
+        var isReadOnlyMethod = typeof(InnovativeForm<TestFormReadOnlyModel>)
+            .GetMethod("IsReadOnly", BindingFlags.NonPublic | BindingFlags.Static);
+        var property = typeof(TestFormReadOnlyModel).GetProperty(nameof(TestFormReadOnlyModel.ReadOnlyString));
+        var attr = property!.GetCustomAttribute<UIFormField>();
+        var result = (bool)isReadOnlyMethod!.Invoke(null
+                                                  , new object[]
+                                                    {
+                                                        property!, attr!
+                                                    })!;
+
+        // Assert
+        Assert.True(result);
+
+        // Also check that a normal property is not read-only
+        var normalProperty = typeof(TestFormReadOnlyModel).GetProperty(nameof(TestFormReadOnlyModel.NormalString));
+        var normalAttr = normalProperty!.GetCustomAttribute<UIFormField>();
+        var normalResult = (bool)isReadOnlyMethod.Invoke(null
+                                                       , new object[]
+                                                         {
+                                                             normalProperty!, normalAttr!
+                                                         })!;
+        Assert.False(normalResult);
+    }
+
+    [UIFormClass("TestFormReadOnlyModel")]
+#pragma warning disable CA1034
+    public class TestFormReadOnlyModel : FormModel
+#pragma warning restore CA1034
+    {
+        [UIFormField(name: nameof(ReadOnlyString), ReadOnly = true)]
+        public string ReadOnlyString { get; set; } = string.Empty;
+
+        [UIFormField(name: nameof(NormalString))]
+        public string NormalString { get; set; } = string.Empty;
+    }
 }
 
 // Test classes
 [UIFormClass("testFormGroupModel")]
-public class TestFormGroupModel: FormModel
+public class TestFormGroupModel : FormModel
 {
-    [UIFormField(name:nameof(GroupedProperty1), ColumnGroup = "Group1")] public string GroupedProperty1 { get; set; } = string.Empty;
+    [UIFormField(name: nameof(GroupedProperty1), ColumnGroup = "Group1")]
+    public string GroupedProperty1 { get; set; } = string.Empty;
 
-    [UIFormField(name:nameof(GroupedProperty2), ColumnGroup = "Group2")] public string GroupedProperty2 { get; set; } = string.Empty;
+    [UIFormField(name: nameof(GroupedProperty2), ColumnGroup = "Group2")]
+    public string GroupedProperty2 { get; set; } = string.Empty;
 
-    [UIFormField(name: nameof(UngroupedProperty))] public string UngroupedProperty { get; set; } = string.Empty;
+    [UIFormField(name: nameof(UngroupedProperty))]
+    public string UngroupedProperty { get; set; } = string.Empty;
 }
 
 [UIFormClass("TestFormColumnWidthModel")]
-public class TestFormColumnWidthModel: FormModel
+public class TestFormColumnWidthModel : FormModel
 {
     public TestFormColumnWidthModel()
     {
@@ -211,22 +269,29 @@ public class TestFormColumnWidthModel: FormModel
         AddViewColumn("Col2", 0, 0, 0);
     }
 
-    [UIFormField(name:nameof(Property1), ColumnGroup = "Col1")] public string Property1 { get; set; } = string.Empty;
+    [UIFormField(name: nameof(Property1), ColumnGroup = "Col1")]
+    public string Property1 { get; set; } = string.Empty;
 
-    [UIFormField(name: nameof(Property2), ColumnGroup = "Col2")] public string Property2 { get; set; } = string.Empty;
+    [UIFormField(name: nameof(Property2), ColumnGroup = "Col2")]
+    public string Property2 { get; set; } = string.Empty;
 }
 
-public class TestFormModel: FormModel
+public class TestFormModel : FormModel
 {
-    [UIFormField(name: nameof(StringProperty))] public string StringProperty { get; set; } = string.Empty;
+    [UIFormField(name: nameof(StringProperty))]
+    public string StringProperty { get; set; } = string.Empty;
 
-    [UIFormField(name: nameof(IntProperty))] public int IntProperty { get; set; }
+    [UIFormField(name: nameof(IntProperty))]
+    public int IntProperty { get; set; }
 
-    [UIFormField(name: nameof(BoolProperty))] public bool BoolProperty { get; set; }
+    [UIFormField(name: nameof(BoolProperty))]
+    public bool BoolProperty { get; set; }
 
-    [UIFormField(name: nameof(DateProperty))] public DateTime DateProperty { get; set; }
+    [UIFormField(name: nameof(DateProperty))]
+    public DateTime DateProperty { get; set; }
 
-    [UIFormViewAction(name: nameof(CustomAction))] public Action<int>? CustomAction { get; set; }
+    [UIFormViewAction(name: nameof(CustomAction))]
+    public Action<int>? CustomAction { get; set; }
 }
 
 // Extension methods to access private methods/properties for testing
@@ -234,45 +299,51 @@ public static class DynamicFormViewTestExtensions
 {
     public static void CallOnParametersSet<T>(this InnovativeForm<T> component)
     {
-        var method = typeof(InnovativeForm<T>).GetMethod("OnParametersSet",
-                                                                    BindingFlags.NonPublic | BindingFlags.Instance);
+        var method = typeof(InnovativeForm<T>).GetMethod("OnParametersSet", BindingFlags.NonPublic | BindingFlags.Instance);
         method?.Invoke(component, null);
     }
 
     public static object? GetFormValue<T>(this InnovativeForm<T> component, string propertyName)
     {
-        var formValuesField = typeof(InnovativeForm<T>).GetField("formValues",
-                                                                            BindingFlags.NonPublic | BindingFlags.Instance);
+        var formValuesField = typeof(InnovativeForm<T>).GetField("formValues", BindingFlags.NonPublic | BindingFlags.Instance);
         var formValues = (Dictionary<string, object>)formValuesField?.GetValue(component)!;
         return formValues?.TryGetValue(propertyName, out var value) == true ? value : null;
     }
 
-    public static void SetFormValue<T>(this InnovativeForm<T> component, string propertyName, object value, bool shouldNotifyChange = false)
+    public static void SetFormValue<T>
+    (
+        this InnovativeForm<T> component
+      , string propertyName
+      , object value
+      , bool shouldNotifyChange = false
+    )
     {
-        var setValueMethod = typeof(InnovativeForm<T>).GetMethod("SetValue",
-                                                                            BindingFlags.NonPublic | BindingFlags.Instance);
-        setValueMethod?.Invoke(component, new[] { propertyName, value, shouldNotifyChange });
+        var setValueMethod = typeof(InnovativeForm<T>).GetMethod("SetValue", BindingFlags.NonPublic | BindingFlags.Instance);
+        setValueMethod?.Invoke(component
+                             , new[]
+                               {
+                                   propertyName, value, shouldNotifyChange
+                               });
     }
 
     public static IReadOnlyCollection<PropertyInfo>? GetUngroupedProperties<T>(this InnovativeForm<T> component)
     {
-        var property = typeof(InnovativeForm<T>).GetProperty("ungroupedProperties",
-                                                                        BindingFlags.NonPublic | BindingFlags.Instance);
+        var property = typeof(InnovativeForm<T>).GetProperty("ungroupedProperties", BindingFlags.NonPublic | BindingFlags.Instance);
         return (IReadOnlyCollection<PropertyInfo>)property?.GetValue(component)!;
     }
 
-    public static IReadOnlyCollection<KeyValuePair<string, List<PropertyInfo>>>? GetOrderedColumnGroups<T>(
-        this InnovativeForm<T> component)
+    public static IReadOnlyCollection<KeyValuePair<string, List<PropertyInfo>>>? GetOrderedColumnGroups<T>
+    (
+        this InnovativeForm<T> component
+    )
     {
-        var property = typeof(InnovativeForm<T>).GetProperty("OrderedColumnGroups",
-                                                                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var property = typeof(InnovativeForm<T>).GetProperty("OrderedColumnGroups", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
         return (IReadOnlyCollection<KeyValuePair<string, List<PropertyInfo>>>)property?.GetValue(component)!;
     }
 
     public static string CallGetColumnWidthClass<T>(this InnovativeForm<T> component, string columnGroup)
     {
-        var method = typeof(InnovativeForm<T>).GetMethod("GetColumnWidthClass",
-                                                                    BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+        var method = typeof(InnovativeForm<T>).GetMethod("GetColumnWidthClass", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
         return (string)method!.Invoke(component, [columnGroup])!;
     }
 
@@ -280,9 +351,9 @@ public static class DynamicFormViewTestExtensions
     {
         var properties = component?.Model?.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance) ?? [];
         var result = properties
-                .Where(x=> x.GetCustomAttribute<UIFormViewAction>() !=null)
-                .ToList()
-                .AsReadOnly();
+                     .Where(x => x.GetCustomAttribute<UIFormViewAction>() != null)
+                     .ToList()
+                     .AsReadOnly();
         return result;
     }
 }


### PR DESCRIPTION
```
### Description

This pull request includes the following changes:

- Updates the version prefix to `0.13.0` in `Directory.Build.props`.
- Adds a `ReadOnly` property to `UIFormField` to support read-only fields.
- Enhances `InnovativeForm` to manage read-only fields effectively.
- Adds unit tests to ensure proper functionality of the new feature.

### Related Issues

_Empty; no related issues were linked._

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [ ] Any dependent changes have been merged and published in downstream modules.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Read-only form fields are now supported and automatically disabled in forms.
  - Form submission syncs form values back to the model; reset restores original values and closes the dialog.
  - Enhanced localization initialization for forms.
  - Added support to pass parameters to custom display/form components, plus new field metadata (TextProperty, DataTestId, ShouldNotifyChanges).
- Documentation
  - Example page expanded with guidance on InnovativeForm and UIFormField options, including ReadOnly behavior.
- Chores
  - Version bumped to 0.13.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->