### PR TITLE
Add selective alert rendering to `InnovativeForm` and `InnovativeDeta…

### DIFF
--- a/Src/Innovative.Blazor.Components/Components/Detail/InnovativeDetail.razor
+++ b/Src/Innovative.Blazor.Components/Components/Detail/InnovativeDetail.razor
@@ -33,6 +33,16 @@
         }
     </RadzenStack>
 
+    @if (Model is FormModel model)
+    {
+        foreach (var alert in model.Alerts.Where(a => a.ShowInDetail))
+        {
+            var capturedId = alert.Id;
+            <InnovativeAlert Severity="@alert.Severity" Summary="@alert.Summary" Detail="@alert.Detail"
+                             Closable="@alert.Closable" OnClose="@(() => model.RemoveAlert(capturedId))"/>
+        }
+    }
+
     <section class="innovative-detail-layout">
         @foreach (var group in orderedColumnGroups)
         {

--- a/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
+++ b/Src/Innovative.Blazor.Components/Components/Form/FormModel.cs
@@ -5,7 +5,7 @@ using Microsoft.Kiota.Abstractions.Serialization;
 
 namespace Innovative.Blazor.Components.Components;
 
-public sealed record FormAlert(Guid Id, AlertSeverity Severity, string Summary, string? Detail, bool Closable);
+public sealed record FormAlert(Guid Id, AlertSeverity Severity, string Summary, string? Detail, bool Closable, bool ShowInForm, bool ShowInDetail);
 
 public abstract class FormModel
 {
@@ -49,12 +49,14 @@ public abstract class FormModel
       , string message
       , bool closable = true
       , string? detail = null
+      , bool inForm = true
+      , bool inDetail = true
     )
     {
         if (string.IsNullOrWhiteSpace(message))
             throw new ArgumentException("Message cannot be null or whitespace.", nameof(message));
         var id = Guid.NewGuid();
-        alerts.Add(new FormAlert(id, severity, message, detail, closable));
+        alerts.Add(new FormAlert(id, severity, message, detail, closable, inForm, inDetail));
         return id;
     }
 

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor
@@ -9,8 +9,8 @@
             var model = Model as FormModel;
             Debug.Assert(model != null, $"{nameof(model)} is null!");
 
-            // Render custom alerts first
-            foreach (var alert in model.Alerts)
+            // Render custom alerts first (only those marked for Form)
+            foreach (var alert in model.Alerts.Where(a => a.ShowInForm))
             {
                 var capturedId = alert.Id;
                 <InnovativeAlert Severity="@alert.Severity" Summary="@alert.Summary" Detail="@alert.Detail"


### PR DESCRIPTION
…il`, update `FormAlert` model fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Alerts can now be targeted to appear in the form view, the detail view, or both.
  - Detail view displays per-alert messages with severity, summary, optional detail, and a close action.
  - Closing an alert removes only that specific message.
  - Adding alerts supports options to control where they are shown (form and/or detail).
- Improvements
  - Form view now shows only alerts intended for it, reducing noise and improving clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->