### PR TITLE
Adjust `InnovativeGrid` min/max height styles in `GetGridStyle`.

### DIFF
--- a/Src/Innovative.Blazor.Components/Components/Grid/InnovativeGrid.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/Grid/InnovativeGrid.razor.cs
@@ -300,10 +300,10 @@ public partial class InnovativeGrid<TItem> : ComponentBase
 
     private string GetGridStyle()
     {
-        var minHeight = MinHeightOption == GridHeight.Max ? "1162px" : "";
+        var minHeight = MinHeightOption == GridHeight.Max ? "1262px" : "";
         return string.IsNullOrEmpty(minHeight)
-                   ? "--max-height: 1162px;"
-                   : $"--max-height: 1162px; --min-height: {minHeight};";
+                   ? "--max-height: 1262px;"
+                   : $"--max-height: 1262px; --min-height: {minHeight};";
     }
 
     [ExcludeFromCodeCoverage]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Increased the grid’s maximum height to 1262px (and aligned minimum height when applicable) when the “Max” height option is selected. This allows more rows to be visible at once and reduces scrolling.
  - Applies automatically to grids using the “Max” height setting; other height options are unaffected. No changes to controls or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->