### PR TITLE
fix/issues-where-form-doesnt-trigger-button

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <ReportAnalyzer>true</ReportAnalyzer>
     <TargetFramework>net9.0</TargetFramework>
-    <VersionPrefix>0.16.0</VersionPrefix>
+    <VersionPrefix>0.17.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Innovative.Blazor.Components.Services;
 using Microsoft.AspNetCore.Components;
 using Radzen;
@@ -6,11 +7,16 @@ using Radzen;
 namespace Innovative.Blazor.Components.Components;
 
 [SuppressMessage("Design", "CA1031:Do not catch general exception types")]
-public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelService) : ComponentBase
+public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelService) : ComponentBase, IDisposable
 {
+
+    private bool _disposed;
     private IFormComponent? formComponent;
     private bool isCustomDialog;
     private string? modelError;
+
+    [Inject]
+    private DialogService DialogService { get; set; } = default!;
 
     [Parameter]
     public bool IsEditing { get; set; }
@@ -59,6 +65,12 @@ public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelServi
 
     public object? ComponentInstance { get; private set; }
 
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
     public void SetFormComponent(IFormComponent? component)
     {
         formComponent = component;
@@ -93,6 +105,54 @@ public partial class SidePanelComponent<TModel>(ISidepanelService sidePanelServi
 
     public void CloseSidepanel() => sidePanelService.CloseSidepanel();
     public void CloseSidepanel(object? result) => sidePanelService.CloseSidepanel(result);
+
+    protected override void OnInitialized()
+    {
+        // Assign confirmation delegate for overlay clicks
+        sidePanelService.BeforeOverlayCloseAsync = ConfirmLeaveIfNeededAsync;
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+            return;
+        if (disposing)
+        {
+            // Clear delegate when component is disposed to avoid dangling references
+            if (sidePanelService.BeforeOverlayCloseAsync == ConfirmLeaveIfNeededAsync)
+            {
+                sidePanelService.BeforeOverlayCloseAsync = null;
+            }
+        }
+        _disposed = true;
+    }
+
+    private async Task<bool> ConfirmLeaveIfNeededAsync()
+    {
+        // Only confirm when user clicks outside (overlay handled by host)
+        if (isCustomDialog || IsEditing)
+        {
+            var isDutch = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName.Equals("nl", StringComparison.OrdinalIgnoreCase);
+            var title = isDutch ? "Bevestigen" : "Confirm";
+            var message = isDutch
+                              ? "Weet je zeker dat je dit paneel wilt verlaten? Niet-opgeslagen wijzigingen gaan verloren."
+                              : "Are you sure you want to leave this panel? Unsaved changes will be lost.";
+            var okText = isDutch ? "Ja, verlaten" : "Yes, leave";
+            var cancelText = isDutch ? "Nee, annuleren" : "No, cancel";
+
+            var result = await DialogService.Confirm(message
+                                                   , title
+                                                   , new ConfirmOptions
+                                                     {
+                                                         OkButtonText = okText
+                                                       , CancelButtonText = cancelText
+                                                     })
+                                            .ConfigureAwait(false);
+
+            return result == true;
+        }
+        return true;
+    }
 
     protected override void OnParametersSet()
     {

--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelHost.razor.cs
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelHost.razor.cs
@@ -5,12 +5,12 @@ namespace Innovative.Blazor.Components.Components;
 
 public sealed partial class SidePanelHost(ISidepanelService sidePanelService)
 {
+    private bool IsVisable = true;
     protected override void OnInitialized()
     {
         sidePanelService.OnStateChanged += StateHasChanged;
         sidePanelService.VisibleChanged += VisibleChanged;
     }
-    private bool IsVisable = true;
     private void VisibleChanged(bool obj)
     {
         //todo: check for fix to solve in the dom
@@ -50,5 +50,17 @@ public sealed partial class SidePanelHost(ISidepanelService sidePanelService)
 
     private void Close() => sidePanelService.CloseSidepanel();
 
-    private void OnOverlayClick(MouseEventArgs e) => sidePanelService.CloseSidepanel();
+    private async void OnOverlayClick(MouseEventArgs e)
+    {
+        if (sidePanelService.BeforeOverlayCloseAsync is null)
+        {
+            sidePanelService.CloseSidepanel();
+            return;
+        }
+        var canClose = await sidePanelService.BeforeOverlayCloseAsync.Invoke().ConfigureAwait(false);
+        if (canClose)
+        {
+            sidePanelService.CloseSidepanel();
+        }
+    }
 }

--- a/Src/Innovative.Blazor.Components/Services/ISidepanelService.cs
+++ b/Src/Innovative.Blazor.Components/Services/ISidepanelService.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.AspNetCore.Components;
 using Innovative.Blazor.Components.Enumerators;
+using Microsoft.AspNetCore.Components;
 
 namespace Innovative.Blazor.Components.Services;
 
@@ -8,6 +8,7 @@ public class SidepanelOptions
 {
     public string? Title { get; set; }
     public string? Width { get; set; } // e.g., "400px", "40%"
+
     public SideDialogWidth SideDialogWidth { get; set; } = SideDialogWidth.Normal;
     // Add more options as needed
 }
@@ -20,8 +21,14 @@ public interface ISidepanelService
     Type? CurrentComponentType { get; }
     Dictionary<string, object>? CurrentParameters { get; }
     SidepanelOptions? CurrentOptions { get; }
+
+    // Delegate invoked by host before closing due to overlay (outside) click.
+    // Should return true to proceed with closing, false to cancel.
+    Func<Task<bool>>? BeforeOverlayCloseAsync { get; set; }
+
     [SuppressMessage("Design", "CA1003:Use generic event handler instances")]
     event Action? OnStateChanged;
+
     Task<object?> OpenSidepanelAsync<T>(Dictionary<string, object> parameters, SidepanelOptions options) where T : IComponent;
     void CloseSidepanel(object? result = null);
 }

--- a/Src/Innovative.Blazor.Components/Services/SidepanelService.cs
+++ b/Src/Innovative.Blazor.Components/Services/SidepanelService.cs
@@ -4,6 +4,8 @@ namespace Innovative.Blazor.Components.Services;
 
 public class SidepanelService : ISidepanelService
 {
+
+    private TaskCompletionSource<object?>? _tcs;
     public bool IsVisible { get; private set; }
     public Action<bool>? VisibleChanged { get; set; }
     public Type? CurrentComponentType { get; private set; }
@@ -11,7 +13,9 @@ public class SidepanelService : ISidepanelService
     public SidepanelOptions? CurrentOptions { get; private set; }
     public event Action? OnStateChanged;
 
-    private TaskCompletionSource<object?>? _tcs;
+    // Delegate invoked by host before closing due to overlay (outside) click.
+    // Should return true to proceed with closing, false to cancel.
+    public Func<Task<bool>>? BeforeOverlayCloseAsync { get; set; }
 
     public Task<object?> OpenSidepanelAsync<T>(Dictionary<string, object> parameters, SidepanelOptions options) where T : IComponent
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a confirmation prompt when closing the side panel with unsaved changes or an active custom dialog.
  - Localization for confirmation dialogs (English and Dutch).
  - Overlay click now respects an optional pre-close check, preventing accidental closure.
  - New option to configure side panel width.

- Chores
  - Bumped version to 0.17.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->