### PR TITLE
Focus styles for side panel buttons & form elements

### DIFF
--- a/ExampleApp/wwwroot/css/app.css
+++ b/ExampleApp/wwwroot/css/app.css
@@ -116,7 +116,7 @@
     --inn-input-checkbox-circle-hover-background-color: var(--inn-gray-300);
 
     /* Focus */
-    --inn-focus-background-color: #fff;
+    --inn-focus-background-color: unset;
     --inn-focus-border-color: var(--inn-gray-900);
     --inn-focus-shadow-color: var(--inn-gray-900);
 

--- a/ExampleApp/wwwroot/css/app.css
+++ b/ExampleApp/wwwroot/css/app.css
@@ -114,7 +114,8 @@
     --inn-input-disabled-background-color: var(--inn-gray-300);
     --inn-input-hover-background-color: #fff;
     --inn-input-focus-background-color: #fff;
-    --inn-input-focus-border-color: var(--inn-primary);
+    --inn-input-focus-border-color: var(--inn-gray-900);
+    --inn-input-focus-shadow-color: var(--inn-gray-900);
     --inn-input-checkbox-circle-hover-background-color: var(--inn-gray-300);
 
     /* Dropdown */
@@ -147,11 +148,11 @@
     --inn-editor-separator-background-color: var(--inn-gray-200);
     --inn-editor-button-selected-background-color: var(--inn-primary-light);
     --inn-editor-button-selected-color: #000;
-    
+
     /* Form group / Fieldset */
     --inn-form-group-background-color: var(--inn-gray-100);
     --inn-form-group-border: var(--inn-gray-200);
-    
+
     /* Side panel */
     --inn-side-panel-background-color: var(--inn-gray-50);
 
@@ -220,7 +221,6 @@
 
     --inn-border-radius: 4px;
 
-    --inn-border: 1px solid var(--inn-border-color-dark);
     --inn-border-1-light: 1px solid var(--inn-border-color-light);
     --inn-border-1-dark: 1px solid var(--inn-border-color-dark);
     --inn-border-2-light: 2px solid var(--inn-border-color-light);
@@ -271,12 +271,12 @@
     --inn-input-hover-border: var(--inn-border-1-dark);
     --inn-input-hover-border-block-end: var(--inn-border-1-dark);
     --inn-input-hover-shadow: none;
-    --inn-input-focus-border: var(--inn-border);
+    --inn-input-focus-border: 1px solid var(--inn-input-focus-border-color);
     --inn-input-focus-border-block-end: var(--inn-border-1-dark);
     --inn-input-focus-border-radius: var(--inn-border-radius);
     --inn-input-focus-outline: none;
     --inn-input-focus-outline-offset: 0;
-    --inn-input-focus-shadow: none;
+    --inn-input-focus-shadow: 0 0 0 1px var(--inn-input-focus-shadow-color);
 
     --inn-checkbox-width: 1.125rem;
     --inn-checkbox-height: 1.125rem;

--- a/ExampleApp/wwwroot/css/app.css
+++ b/ExampleApp/wwwroot/css/app.css
@@ -113,10 +113,10 @@
     --inn-input-background-color: #fff;
     --inn-input-disabled-background-color: var(--inn-gray-300);
     --inn-input-hover-background-color: #fff;
-    --inn-input-focus-background-color: #fff;
-    --inn-input-focus-border-color: var(--inn-gray-900);
-    --inn-input-focus-shadow-color: var(--inn-gray-900);
     --inn-input-checkbox-circle-hover-background-color: var(--inn-gray-300);
+    --inn-focus-background-color: #fff;
+    --inn-focus-border-color: var(--inn-gray-900);
+    --inn-focus-shadow-color: var(--inn-gray-900);
 
     /* Dropdown */
     --inn-dropdown-background-color: #fff;
@@ -271,12 +271,12 @@
     --inn-input-hover-border: var(--inn-border-1-dark);
     --inn-input-hover-border-block-end: var(--inn-border-1-dark);
     --inn-input-hover-shadow: none;
-    --inn-input-focus-border: 1px solid var(--inn-input-focus-border-color);
-    --inn-input-focus-border-block-end: var(--inn-border-1-dark);
-    --inn-input-focus-border-radius: var(--inn-border-radius);
-    --inn-input-focus-outline: none;
-    --inn-input-focus-outline-offset: 0;
-    --inn-input-focus-shadow: 0 0 0 1px var(--inn-input-focus-shadow-color);
+    --inn-focus-border: 1px solid var(--inn-focus-border-color);
+    --inn-focus-border-block-end: var(--inn-border-1-dark);
+    --inn-focus-border-radius: var(--inn-border-radius);
+    --inn-focus-outline: none;
+    --inn-focus-outline-offset: 0;
+    --inn-focus-shadow: 0 0 0 1px var(--inn-focus-shadow-color);
 
     --inn-checkbox-width: 1.125rem;
     --inn-checkbox-height: 1.125rem;

--- a/ExampleApp/wwwroot/css/app.css
+++ b/ExampleApp/wwwroot/css/app.css
@@ -114,6 +114,8 @@
     --inn-input-disabled-background-color: var(--inn-gray-300);
     --inn-input-hover-background-color: #fff;
     --inn-input-checkbox-circle-hover-background-color: var(--inn-gray-300);
+
+    /* Focus */
     --inn-focus-background-color: #fff;
     --inn-focus-border-color: var(--inn-gray-900);
     --inn-focus-shadow-color: var(--inn-gray-900);
@@ -271,12 +273,6 @@
     --inn-input-hover-border: var(--inn-border-1-dark);
     --inn-input-hover-border-block-end: var(--inn-border-1-dark);
     --inn-input-hover-shadow: none;
-    --inn-focus-border: 1px solid var(--inn-focus-border-color);
-    --inn-focus-border-block-end: var(--inn-border-1-dark);
-    --inn-focus-border-radius: var(--inn-border-radius);
-    --inn-focus-outline: none;
-    --inn-focus-outline-offset: 0;
-    --inn-focus-shadow: 0 0 0 1px var(--inn-focus-shadow-color);
 
     --inn-checkbox-width: 1.125rem;
     --inn-checkbox-height: 1.125rem;
@@ -290,6 +286,14 @@
     --inn-numeric-input-padding-block: 0.4375rem;
     --inn-numeric-input-padding-inline: 0.9375rem 1.25rem;
     --inn-numeric-button-offset: 2px;
+
+    /* Focus */
+    --inn-focus-border: 1px solid var(--inn-focus-border-color);
+    --inn-focus-border-block-end: var(--inn-border-1-dark);
+    --inn-focus-border-radius: var(--inn-border-radius);
+    --inn-focus-outline: none;
+    --inn-focus-outline-offset: 0;
+    --inn-focus-shadow: 0 0 0 1px var(--inn-focus-shadow-color);
 
     /* Datepicker */
     --inn-datepicker-popup-width: 22rem;

--- a/ExampleApp/wwwroot/css/app.css
+++ b/ExampleApp/wwwroot/css/app.css
@@ -116,7 +116,6 @@
     --inn-input-checkbox-circle-hover-background-color: var(--inn-gray-300);
 
     /* Focus */
-    --inn-focus-background-color: unset;
     --inn-focus-border-color: var(--inn-gray-900);
     --inn-focus-shadow-color: var(--inn-gray-900);
 

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.css
@@ -149,13 +149,13 @@
 ::deep .mask:not(:disabled):not(.rz-state-disabled):focus,
 ::deep .rz-textarea:not(:disabled):not(.rz-state-disabled):focus,
 ::deep .rz-textbox:not(:disabled):not(.rz-state-disabled):focus {
-    background-color: var(--inn-input-focus-background-color);
-    border: var(--inn-input-focus-border);
-    border-color: var(--inn-input-focus-border-color);
-    border-block-end: var(--inn-input-focus-border-block-end);
-    box-shadow: var(--inn-input-focus-shadow);
-    outline: var(--inn-input-focus-outline);
-    outline-offset: var(--inn-input-focus-outline-offset);
+    background-color: var(--inn-focus-background-color);
+    border: var(--inn-focus-border);
+    border-color: var(--inn-focus-border-color);
+    border-block-end: var(--inn-focus-border-block-end);
+    box-shadow: var(--inn-focus-shadow);
+    outline: var(--inn-focus-outline);
+    outline-offset: var(--inn-focus-outline-offset);
 }
 
 ::deep .rz-state-highlight.rz-menuitem:hover,
@@ -244,12 +244,12 @@
 
 ::deep .rz-html-editor:focus-within {
     background-color: var(--inn-focus-background-color);
-    border: var(--inn-input-focus-border);
-    border-color: var(--inn-input-focus-border-color);
-    border-block-end: var(--inn-input-focus-border-block-end);
-    box-shadow: var(--inn-input-focus-shadow);
-    outline: var(--inn-input-focus-outline);
-    outline-offset: var(--inn-input-focus-outline-offset);
+    border: var(--inn-focus-border);
+    border-color: var(--inn-focus-border-color);
+    border-block-end: var(--inn-focus-border-block-end);
+    box-shadow: var(--inn-focus-shadow);
+    outline: var(--inn-focus-outline);
+    outline-offset: var(--inn-focus-outline-offset);
 }
 
 ::deep .rz-html-editor-toolbar {

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.css
@@ -149,7 +149,6 @@
 ::deep .mask:not(:disabled):not(.rz-state-disabled):focus,
 ::deep .rz-textarea:not(:disabled):not(.rz-state-disabled):focus,
 ::deep .rz-textbox:not(:disabled):not(.rz-state-disabled):focus {
-    background-color: var(--inn-focus-background-color);
     border: var(--inn-focus-border);
     border-color: var(--inn-focus-border-color);
     border-block-end: var(--inn-focus-border-block-end);
@@ -243,7 +242,6 @@
 }
 
 ::deep .rz-html-editor:focus-within {
-    background-color: var(--inn-focus-background-color);
     border: var(--inn-focus-border);
     border-color: var(--inn-focus-border-color);
     border-block-end: var(--inn-focus-border-block-end);

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.css
@@ -243,8 +243,13 @@
 }
 
 ::deep .rz-html-editor:focus-within {
-    outline: var(--inn-editor-focus-outline);
-    outline-offset: var(--inn-editor-focus-outline-offset);
+    background-color: var(--inn-input-focus-background-color);
+    border: var(--inn-input-focus-border);
+    border-color: var(--inn-input-focus-border-color);
+    border-block-end: var(--inn-input-focus-border-block-end);
+    box-shadow: var(--inn-input-focus-shadow);
+    outline: var(--inn-input-focus-outline);
+    outline-offset: var(--inn-input-focus-outline-offset);
 }
 
 ::deep .rz-html-editor-toolbar {

--- a/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Form/InnovativeForm.razor.css
@@ -243,7 +243,7 @@
 }
 
 ::deep .rz-html-editor:focus-within {
-    background-color: var(--inn-input-focus-background-color);
+    background-color: var(--inn-focus-background-color);
     border: var(--inn-input-focus-border);
     border-color: var(--inn-input-focus-border-color);
     border-block-end: var(--inn-input-focus-border-block-end);

--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.css
@@ -52,6 +52,16 @@
     box-shadow: var(--inn-button-hover-shadow);
 }
 
+.sidepanel-icon-button:focus {
+    background-color: var(--inn-focus-background-color);
+    border: var(--inn-focus-border);
+    border-color: var(--inn-focus-border-color);
+    border-block-end: var(--inn-focus-border-block-end);
+    box-shadow: var(--inn-focus-shadow);
+    outline: var(--inn-focus-outline);
+    outline-offset: var(--inn-focus-outline-offset);
+}
+
 .sidepanel-icon-button .material-symbols-outlined {
     color: var(--inn-button-base-text-color);
     font-size: var(--inn-icon-font-size);
@@ -77,8 +87,13 @@
     box-shadow: var(--inn-button-hover-shadow);
 }
 ::deep .rz-button.rz-primary.rz-shade-default:focus {
-    border:1px solid var(--inn-gray-900);
-    box-shadow:0 0 0 1px var(--inn-gray-900);
+    background-color: var(--inn-focus-background-color);
+    border: var(--inn-focus-border);
+    border-color: var(--inn-focus-border-color);
+    border-block-end: var(--inn-focus-border-block-end);
+    box-shadow: var(--inn-focus-shadow);
+    outline: var(--inn-focus-outline);
+    outline-offset: var(--inn-focus-outline-offset);
 }
 ::deep .rz-button.rz-primary.rz-shade-default .material-symbols-outlined {
     color: var(--inn-button-primary-text-color, var(--inn-gray-50));
@@ -99,8 +114,13 @@
     box-shadow: var(--inn-button-hover-shadow);
 }
 ::deep .rz-button.rz-secondary.rz-shade-default:focus {
-    border:1px solid var(--inn-gray-900);
-    box-shadow:0 0 0 1px var(--inn-gray-900);
+    background-color: var(--inn-focus-background-color);
+    border: var(--inn-focus-border);
+    border-color: var(--inn-focus-border-color);
+    border-block-end: var(--inn-focus-border-block-end);
+    box-shadow: var(--inn-focus-shadow);
+    outline: var(--inn-focus-outline);
+    outline-offset: var(--inn-focus-outline-offset);
 }
 ::deep .rz-button.rz-secondary.rz-shade-default .material-symbols-outlined {
     color: var(--inn-button-secondary-text-color, var(--inn-gray-50));
@@ -121,8 +141,13 @@
     box-shadow: var(--inn-button-hover-shadow);
 }
 ::deep .rz-button.rz-danger.rz-shade-default:focus {
-    border:1px solid var(--inn-gray-900);
-    box-shadow:0 0 0 1px var(--inn-gray-900);
+    background-color: var(--inn-focus-background-color);
+    border: var(--inn-focus-border);
+    border-color: var(--inn-focus-border-color);
+    border-block-end: var(--inn-focus-border-block-end);
+    box-shadow: var(--inn-focus-shadow);
+    outline: var(--inn-focus-outline);
+    outline-offset: var(--inn-focus-outline-offset);
 }
 ::deep .rz-button.rz-danger.rz-shade-default .material-symbols-outlined {
     color: var(--inn-button-danger-text-color, var(--inn-danger-darker));

--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.css
@@ -53,7 +53,6 @@
 }
 
 .sidepanel-icon-button:focus {
-    background-color: var(--inn-focus-background-color);
     border: var(--inn-focus-border);
     border-color: var(--inn-focus-border-color);
     border-block-end: var(--inn-focus-border-block-end);
@@ -87,7 +86,6 @@
     box-shadow: var(--inn-button-hover-shadow);
 }
 ::deep .rz-button.rz-primary.rz-shade-default:focus {
-    background-color: var(--inn-focus-background-color);
     border: var(--inn-focus-border);
     border-color: var(--inn-focus-border-color);
     border-block-end: var(--inn-focus-border-block-end);
@@ -114,7 +112,6 @@
     box-shadow: var(--inn-button-hover-shadow);
 }
 ::deep .rz-button.rz-secondary.rz-shade-default:focus {
-    background-color: var(--inn-focus-background-color);
     border: var(--inn-focus-border);
     border-color: var(--inn-focus-border-color);
     border-block-end: var(--inn-focus-border-block-end);

--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.css
@@ -76,6 +76,10 @@
     background-color: var(--inn-button-primary-hover-background-color, var(--inn-primary-dark));
     box-shadow: var(--inn-button-hover-shadow);
 }
+::deep .rz-button.rz-primary.rz-shade-default:focus {
+    border:1px solid var(--inn-gray-900);
+    box-shadow:0 0 0 1px var(--inn-gray-900);
+}
 ::deep .rz-button.rz-primary.rz-shade-default .material-symbols-outlined {
     color: var(--inn-button-primary-text-color, var(--inn-gray-50));
     font-size: var(--inn-icon-font-size);
@@ -94,6 +98,10 @@
     background-color: var(--inn-button-secondary-hover-background-color, var(--inn-secondary-dark));
     box-shadow: var(--inn-button-hover-shadow);
 }
+::deep .rz-button.rz-secondary.rz-shade-default:focus {
+    border:1px solid var(--inn-gray-900);
+    box-shadow:0 0 0 1px var(--inn-gray-900);
+}
 ::deep .rz-button.rz-secondary.rz-shade-default .material-symbols-outlined {
     color: var(--inn-button-secondary-text-color, var(--inn-gray-50));
     font-size: var(--inn-icon-font-size);
@@ -111,6 +119,10 @@
 ::deep .rz-button.rz-danger.rz-shade-default:hover {
     background-color: var(--inn-button-danger-hover-background-color, var(--inn-danger-dark));
     box-shadow: var(--inn-button-hover-shadow);
+}
+::deep .rz-button.rz-danger.rz-shade-default:focus {
+    border:1px solid var(--inn-gray-900);
+    box-shadow:0 0 0 1px var(--inn-gray-900);
 }
 ::deep .rz-button.rz-danger.rz-shade-default .material-symbols-outlined {
     color: var(--inn-button-danger-text-color, var(--inn-danger-darker));


### PR DESCRIPTION
- Focus shadow color
- Improved focus styling for html editor
- Focus styling for side panel buttons

Alle elementen hebben tenminste deze focus css code nodig
```css
self:focus {
    border:1px solid var(--inn-gray-900);
    box-shadow:0 0 0 1px var(--inn-gray-900);
}
```

**Nieuwe focus ontwerpen**
<img width="431" height="148" alt="Screenshot 2025-11-10 112726" src="https://github.com/user-attachments/assets/e34ce944-25d1-49e2-b3ee-eb7170f92d9e" />
<img width="868" height="507" alt="Screenshot 2025-11-10 112714" src="https://github.com/user-attachments/assets/36f80b5d-d56b-4e0d-8b13-41bd348e8ba7" />

**Oude ontwerpen**
<img width="426" height="90" alt="Screenshot 2025-11-10 113647" src="https://github.com/user-attachments/assets/4e85fb3d-3621-4434-8372-b6bbbc4c8a81" />
<img width="867" height="416" alt="Screenshot 2025-11-10 113715" src="https://github.com/user-attachments/assets/1e369c5e-bf8c-4ef8-ac47-8543c1479f6c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized focus styling across inputs, editors, side-panel buttons, and other controls for more consistent visual feedback.

* **Refactor**
  * Consolidated per-input focus settings into a centralized focus token system and removed legacy per-control focus declarations to simplify maintenance and ensure uniform behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->