### PR TITLE
Improved alert styles

### DIFF
--- a/ExampleApp/wwwroot/css/app.css
+++ b/ExampleApp/wwwroot/css/app.css
@@ -87,7 +87,7 @@
     --inn-text-color-on-secondary-dark: #fff;
     --inn-text-color-on-secondary-darker: #fff;
 
-    --inn-shadow-color: var(--inn-gray-900);
+    --inn-shadow-color: var(--inn-secondary);
 
     /* Component Colors */
     /* Button */

--- a/ExampleApp/wwwroot/css/app.css
+++ b/ExampleApp/wwwroot/css/app.css
@@ -2,47 +2,47 @@
 :root {
     /* Global Colors */
     --inn-gray-50: #f2f2f2;
-    --inn-gray-100: #ebeaea;
-    --inn-gray-200: #d7d4d4;
-    --inn-gray-300: #bcb6b6;
+    --inn-gray-100: #e6e5e5;
+    --inn-gray-200: #cecaca;
+    --inn-gray-300: #b6afaf;
     --inn-gray-400: #a09898;
-    --inn-gray-500: #857b7b;
-    --inn-gray-600: #675f5f;
-    --inn-gray-700: #494343;
-    --inn-gray-800: #2b2828;
+    --inn-gray-500: #6a6262;
+    --inn-gray-600: #504949;
+    --inn-gray-700: #353131;
+    --inn-gray-800: #1b1818;
     --inn-gray-900: #0d0c0c;
     --inn-base: var(--inn-gray-50);
 
+    --inn-primary-lighter: #fbf2ef;
+    --inn-primary-light: #e4906c;
     --inn-primary: #a43f13;
-    --inn-primary-light: #db8d75;
-    --inn-primary-lighter: #f3e3dd;
-    --inn-primary-dark: #651c06;
-    --inn-primary-darker: unset;
+    --inn-primary-dark: #7d2b07;
+    --inn-primary-darker: #511900;
+    --inn-secondary-lighter: #f4f5f6;
+    --inn-secondary-light: #97b4ba;
     --inn-secondary: #406e77;
-    --inn-secondary-light: #8ebac2;
-    --inn-secondary-lighter: #f2f7f8;
-    --inn-secondary-dark: #2e5056;
-    --inn-secondary-darker: unset;
+    --inn-secondary-dark: #28555d;
+    --inn-secondary-darker: #28555d;
 
-    --inn-danger: #e52421;
-    --inn-danger-light: #e46e6c;
     --inn-danger-lighter: #f6dbda;
-    --inn-danger-dark: #950b09;
+    --inn-danger-light: #f4c3c3;
+    --inn-danger: #e5231f;
+    --inn-danger-dark: #7d0907;
     --inn-danger-darker: #6a0301;
-    --inn-success: #61e51f;
-    --inn-success-light: #94e46c;
     --inn-success-lighter: #e4f6db;
-    --inn-success-dark: #41ae0a;
-    --inn-success-darker: #246b01;
+    --inn-success-light: #d3f4c3;
+    --inn-success: #61e51f;
+    --inn-success-dark: #2f7d07;
+    --inn-success-darker: #246a01;
+    --inn-warning-lighter: #f6eadb;
+    --inn-warning-light: #f4dfc3;
     --inn-warning: #e5931f;
-    --inn-warning-light: #e4b26c;
-    --inn-warning-lighter: #f6e9db;
-    --inn-warning-dark: #ae690a;
+    --inn-warning-dark: #7d4c07;
     --inn-warning-darker: #6a3e01;
-    --inn-info: #1fa3e5;
-    --inn-info-light: #daedf6;
     --inn-info-lighter: #dbedf6;
-    --inn-info-dark: #0a77ae;
+    --inn-info-light: #c3e4f4;
+    --inn-info: #1fa3e5;
+    --inn-info-dark: #07567d;
     --inn-info-darker: #01476a;
 
     --inn-border-color-light: var(--inn-gray-400);
@@ -180,8 +180,30 @@
     --inn-dialog-background-color: var(--inn-gray-100);
 
     /* Alert */
-    --inn-alert-close-background: none;
-    --inn-alert-close-background-hover: rgba(0,0,0,.1);
+    --inn-alert-danger-icon-color: var(--inn-danger);
+    --inn-alert-danger-text-color: var(--inn-gray-900);
+    --inn-alert-danger-background-color: var(--inn-danger-lighter);
+    --inn-alert-danger-close-text-color: var(--inn-gray-900);
+    --inn-alert-danger-close-background-color: var(--inn-danger-light);
+    --inn-alert-danger-close-hover-background-color: var(--inn-gray-200);
+    --inn-alert-success-icon-color: var(--inn-success);
+    --inn-alert-success-text-color: var(--inn-gray-900);
+    --inn-alert-success-background-color: var(--inn-success-lighter);
+    --inn-alert-success-close-text-color: var(--inn-gray-900);
+    --inn-alert-success-close-background-color: var(--inn-success-light);
+    --inn-alert-success-close-hover-background-color: var(--inn-gray-200);
+    --inn-alert-warning-icon-color: var(--inn-warning);
+    --inn-alert-warning-text-color: var(--inn-gray-900);
+    --inn-alert-warning-background-color: var(--inn-warning-lighter);
+    --inn-alert-warning-close-text-color: var(--inn-gray-900);
+    --inn-alert-warning-close-background-color: var(--inn-warning-light);
+    --inn-alert-warning-close-hover-background-color: var(--inn-gray-200);
+    --inn-alert-info-icon-color: var(--inn-info);
+    --inn-alert-info-text-color: var(--inn-gray-900);
+    --inn-alert-info-background-color: var(--inn-info-lighter);
+    --inn-alert-info-close-text-color: var(--inn-gray-900);
+    --inn-alert-info-close-background-color: var(--inn-info-light);
+    --inn-alert-info-close-hover-background-color: var(--inn-gray-200);
 
     /* Progress bar circular */
     --inn-progressbar-circular-background-color: var(--inn-gray-100);

--- a/Src/Innovative.Blazor.Components/Components/Alert/InnovativeAlert.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Alert/InnovativeAlert.razor.css
@@ -14,83 +14,83 @@
 
 
 .innovative-alert-error > .material-symbols-outlined {
-    color: var(--inn-alert-danger-icon-color);
+    color: var(--inn-alert-danger-icon-color, var(--inn-danger));
     align-self: center;
 }
 
 .innovative-alert-error {
-    color: var(--inn-alert-danger-text-color);
-    background: var(--inn-alert-danger-background-color);
+    color: var(--inn-alert-danger-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-danger-background-color, var(--inn-danger-lighter));
 }
 
 .innovative-alert-error .innovative-alert-close {
-    color: var(--inn-alert-danger-close-text-color);
-    background: var(--inn-alert-danger-close-background-color);
+    color: var(--inn-alert-danger-close-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-danger-close-background-color, var(--inn-danger-light));
 }
 
 .innovative-alert-error .innovative-alert-close:hover {
-    color: var(--inn-alert-danger-close-text-color);
-    background: var(--inn-alert-danger-close-hover-background-color);
+    color: var(--inn-alert-danger-close-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-danger-close-hover-background-color, var(--inn-gray-200));
 }
 
 .innovative-alert-success > .material-symbols-outlined {
-    color: var(--inn-alert-success-icon-color);
+    color: var(--inn-alert-success-icon-color, var(--inn-success));
     align-self: center;
 }
 
 .innovative-alert-success {
-    color: var(--inn-alert-success-text-color);
-    background: var(--inn-alert-success-background-color);
+    color: var(--inn-alert-success-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-success-background-color, var(--inn-success-lighter));
 }
 
 .innovative-alert-success .innovative-alert-close {
-    color: var(--inn-alert-success-close-text-color);
-    background: var(--inn-alert-success-close-background-color);
+    color: var(--inn-alert-success-close-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-success-close-background-color, var(--inn-success-light));
 }
 
 .innovative-alert-success .innovative-alert-close:hover {
-    color: var(--inn-alert-success-close-text-color);
-    background: var(--inn-alert-success-close-hover-background-color);
+    color: var(--inn-alert-success-close-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-success-close-hover-background-color, var(--inn-gray-200));
 }
 
 .innovative-alert-warning > .material-symbols-outlined {
-    color: var(--inn-alert-warning-icon-color);
+    color: var(--inn-alert-warning-icon-color, var(--inn-warning));
     align-self: center;
 }
 
 .innovative-alert-warning {
-    color: var(--inn-alert-warning-text-color);
-    background: var(--inn-alert-warning-background-color);
+    color: var(--inn-alert-warning-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-warning-background-color, var(--inn-warning-lighter));
 }
 
 .innovative-alert-warning .innovative-alert-close {
-    color: var(--inn-alert-warning-close-text-color);
-    background: var(--inn-alert-warning-close-background-color);
+    color: var(--inn-alert-warning-close-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-warning-close-background-color, var(--inn-warning-light));
 }
 
 .innovative-alert-warning .innovative-alert-close:hover {
-    color: var(--inn-alert-warning-close-text-color);
-    background: var(--inn-alert-warning-close-hover-background-color);
+    color: var(--inn-alert-warning-close-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-warning-close-hover-background-color, var(--inn-gray-200));
 }
 
 .innovative-alert-info > .material-symbols-outlined {
-    color: var(--inn-alert-info-icon-color);
+    color: var(--inn-alert-info-icon-color, var(--inn-info));
     align-self: center;
 }
 
 .innovative-alert-info {
-    color: var(--inn-alert-info-text-color);
-    background: var(--inn-alert-info-background-color);
+    color: var(--inn-alert-info-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-info-background-color, var(--inn-info-lighter));
 }
 
 .innovative-alert-info .innovative-alert-close {
-    color: var(--inn-alert-info-close-text-color);
-    background: var(--inn-alert-info-close-background-color);
+    color: var(--inn-alert-info-close-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-info-close-background-color, var(--inn-info-light));
 }
 
 .innovative-alert-info .innovative-alert-close:hover {
-    color: var(--inn-alert-info-close-text-color);
-    background: var(--inn-alert-info-close-hover-background-color);
+    color: var(--inn-alert-info-close-text-color, var(--inn-gray-900));
+    background: var(--inn-alert-info-close-hover-background-color, var(--inn-gray-200));
 }
 
 .innovative-alert-close {

--- a/Src/Innovative.Blazor.Components/Components/Alert/InnovativeAlert.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Alert/InnovativeAlert.razor.css
@@ -12,30 +12,88 @@
     box-shadow: var(--inn-alert-shadow);
 }
 
-.innovative-alert-info {
-    background: var(--inn-info-light);
-    color: var(--inn-text-color-on-info-light);
-}
 
-.innovative-alert-success {
-    background: var(--inn-success-light);
-    color: var(--inn-text-color-on-success-light);
-}
-
-.innovative-alert-warning {
-    background: var(--inn-warning-light);
-    color: var(--inn-text-color-on-warning-light);
+.innovative-alert-error > .material-symbols-outlined {
+    color: var(--inn-alert-danger-icon-color);
+    align-self: center;
 }
 
 .innovative-alert-error {
-    background: var(--inn-danger-light);
-    color: var(--inn-text-color-on-danger-light);
+    color: var(--inn-alert-danger-text-color);
+    background: var(--inn-alert-danger-background-color);
+}
+
+.innovative-alert-error .innovative-alert-close {
+    color: var(--inn-alert-danger-close-text-color);
+    background: var(--inn-alert-danger-close-background-color);
+}
+
+.innovative-alert-error .innovative-alert-close:hover {
+    color: var(--inn-alert-danger-close-text-color);
+    background: var(--inn-alert-danger-close-hover-background-color);
+}
+
+.innovative-alert-success > .material-symbols-outlined {
+    color: var(--inn-alert-success-icon-color);
+    align-self: center;
+}
+
+.innovative-alert-success {
+    color: var(--inn-alert-success-text-color);
+    background: var(--inn-alert-success-background-color);
+}
+
+.innovative-alert-success .innovative-alert-close {
+    color: var(--inn-alert-success-close-text-color);
+    background: var(--inn-alert-success-close-background-color);
+}
+
+.innovative-alert-success .innovative-alert-close:hover {
+    color: var(--inn-alert-success-close-text-color);
+    background: var(--inn-alert-success-close-hover-background-color);
+}
+
+.innovative-alert-warning > .material-symbols-outlined {
+    color: var(--inn-alert-warning-icon-color);
+    align-self: center;
+}
+
+.innovative-alert-warning {
+    color: var(--inn-alert-warning-text-color);
+    background: var(--inn-alert-warning-background-color);
+}
+
+.innovative-alert-warning .innovative-alert-close {
+    color: var(--inn-alert-warning-close-text-color);
+    background: var(--inn-alert-warning-close-background-color);
+}
+
+.innovative-alert-warning .innovative-alert-close:hover {
+    color: var(--inn-alert-warning-close-text-color);
+    background: var(--inn-alert-warning-close-hover-background-color);
+}
+
+.innovative-alert-info > .material-symbols-outlined {
+    color: var(--inn-alert-info-icon-color);
+    align-self: center;
+}
+
+.innovative-alert-info {
+    color: var(--inn-alert-info-text-color);
+    background: var(--inn-alert-info-background-color);
+}
+
+.innovative-alert-info .innovative-alert-close {
+    color: var(--inn-alert-info-close-text-color);
+    background: var(--inn-alert-info-close-background-color);
+}
+
+.innovative-alert-info .innovative-alert-close:hover {
+    color: var(--inn-alert-info-close-text-color);
+    background: var(--inn-alert-info-close-hover-background-color);
 }
 
 .innovative-alert-close {
-    grid-column: 3; /* always after text */
-    align-self: start;
-    justify-self: end;
     padding: var(--inn-alert-close-padding);
     color: inherit;
     line-height: var(--inn-alert-line-height);
@@ -43,32 +101,30 @@
     height: var(--inn-alert-close-height);
     display: grid;
     place-items: center;
-    background: var(--inn-alert-close-background);
     border: var(--inn-alert-close-border);
     border-radius: var(--inn-alert-close-border-radius);
     cursor: pointer;
     transition: background 0.2s;
-}
-
-.innovative-alert-close:hover {
-    background: var(--inn-alert-close-background-hover);
+    grid-row: 1;
+    grid-column: 3 / 4; /* Last/third column always after text */
 }
 
 .innovative-alert-summary {
     font-weight: bold;
     font-size: var(--inn-alert-summary-font-size);
     display: flex;
-    grid-column: 2;
+    grid-column: 2 / 3; /* Second column */
+    align-self: center;
 }
 
 .innovative-alert-detail {
     font-size: var(--inn-alert-detail-font-size);
-    grid-column: 2 / 4; /* span under the close column */
+    grid-column: 2 / 3;
 }
 
 .innovative-alert-content {
     margin-top: 0.5em;
-    grid-column: 2 / 4; /* span under the close column */
+    grid-column: 2 / 3;
 }
 
 .material-symbols-outlined {


### PR DESCRIPTION
**Alert**
- De achtergrond kleur is wat lichter zodat de tekst beter te lezen is.
- Tekst kleur variabelen verbeterd (--inn-alert-...-text-color).
- Icoon kleur is nu een felle kleur om de alert een beetje opvallender te maken en om de danger kleur terug blijft komen in de website.

**Sluit knop**
- Betere positie -> Naast de tekst en helemaal aan de rechterkant
- Hebben nu een lichte achtergrond kleur
- Icoon kleur variabelen verbeterd (--inn-alert-...-close-text-color).

**Nieuwe design**
<img width="1688" height="1213" alt="Screenshot 2025-11-12 152137" src="https://github.com/user-attachments/assets/dd2fa1c7-3749-46cc-95c7-1ede6b4c7cd3" />

**Oude design**
<img width="1826" height="1162" alt="Screenshot 2025-11-12 151930" src="https://github.com/user-attachments/assets/51eae3b2-fe02-42fc-a6fe-8a46e7c4a525" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application color palette for improved visual consistency and darker theme variants.
  * Enhanced alert styling with better visual distinction for error, success, warning, and info messages.
  * Improved focus indicator visibility across form inputs, buttons, and interactive elements in the side panel for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->