### PR TITLE
Spelling error save inside translations

### DIFF
--- a/Src/Innovative.Blazor.Components/Localizations/Translations.nl.resx
+++ b/Src/Innovative.Blazor.Components/Localizations/Translations.nl.resx
@@ -163,6 +163,6 @@
     <value>Geen data gevonden</value>
   </data>
   <data name="Saving" xml:space="preserve">
-    <value>Oplsaan...</value>
+    <value>Opslaan...</value>
   </data>
 </root>


### PR DESCRIPTION
Ik heb "Oplsaan" naar "Opslaan" veranderd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Dutch translation label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->