### PR TITLE
Improved grid css variables for dark mode

### DIFF
--- a/ExampleApp/wwwroot/css/app.css
+++ b/ExampleApp/wwwroot/css/app.css
@@ -163,7 +163,11 @@
     --inn-grid-row-odd-background-color: #fff;
     --inn-grid-row-even-background-color: var(--inn-gray-50);
     --inn-grid-selected-color: var(--inn-primary);
+    --inn-grid-selected-background-color: unset;
     --inn-grid-filter-color: var(--inn-gray-500);
+    --inn-grid-row-focus-background-color: unset;
+    --inn-grid-row-focus-color: var(--inn-gray-900);
+    --inn-grid-row-focus-border-color: var(--inn-gray-900);
     --inn-grid-header-filter-icon-hover-color: var(--inn-gray-600);
     --inn-grid-sort-icon-color: var(--inn-gray-500);
 

--- a/Src/Innovative.Blazor.Components/Components/Grid/InnovativeGrid.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Grid/InnovativeGrid.razor.css
@@ -44,8 +44,8 @@
     font-weight: var(--inn-grid-header-font-weight);
 }
 
-::deep .rz-grid-table thead th div {
-    background: var(--inn-grid-background-color);
+::deep .rz-grid-table thead th > div {
+    background: var(--inn-grid-header-background-color, #fff);
 }
 
 ::deep .rz-column-title-content {
@@ -57,11 +57,11 @@
 }
 
 /* Table body */
-::deep .rz-grid-table-striped tbody > tr:not(.rz-expanded-row-content):nth-child(2n+1) > td {
+::deep .rz-grid-table tbody > tr:nth-child(2n+1) > td {
     background-color: var(--inn-grid-row-odd-background-color);
 }
 
-::deep .rz-grid-table-striped tbody > tr:not(.rz-expanded-row-content):nth-child(2n) > td {
+::deep .rz-grid-table tbody > tr:nth-child(2n) > td {
     background-color: var(--inn-grid-row-even-background-color);
 }
 
@@ -75,9 +75,18 @@
     cursor: pointer;
 }
 
-::deep .rz-selectable tbody tr.rz-data-row.rz-state-highlight .rz-cell-data {
+::deep .rz-selectable tbody tr.rz-data-row.rz-state-highlight .rz-cell-data,
+::deep .rz-selectable tbody tr.rz-data-row.rz-state-highlight > td {
     color: var(--inn-grid-selected-color);
     font-weight: var(--inn-grid-selected-font-weight);
+    background: var(--inn-grid-selected-background-color);
+}
+
+::deep .rz-selectable tbody tr.rz-data-row.rz-state-focused > td {
+    background-color: var(--inn-grid-row-focus-background-color);
+    color: var(--inn-grid-row-focus-color);
+    border-top: 1px solid var(--inn-grid-row-focus-border-color);
+    border-bottom: 1px solid var(--inn-grid-row-focus-border-color);
 }
 
 ::deep .rz-selectable tbody tr.rz-data-row.rz-state-highlight div {
@@ -117,6 +126,14 @@
 }
 
 /* Frozen grid column */
+.rz-grid-table-striped tbody > tr:nth-child(odd) > td.rz-frozen-cell {
+    background-color: var(--inn-grid-row-odd-background-color);
+}
+
+.rz-grid-table-striped tbody > tr:nth-child(even) > td.rz-frozen-cell {
+    background-color: var(--inn-grid-row-even-background-color);
+}
+
 ::deep .rz-selectable tbody tr.rz-data-row td.rz-frozen-cell:before,
 .rz-selectable tbody tr.rz-data-row td.rz-frozen-cell:after,
 .rz-selectable tbody tr.rz-data-row .rz-cell-data.rz-frozen-cell:before,

--- a/Src/Innovative.Blazor.Components/Components/Grid/InnovativeGrid.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Grid/InnovativeGrid.razor.css
@@ -128,10 +128,12 @@
 }
 
 /* Frozen grid column */
+.rz-grid-table tbody > tr:nth-child(odd) > td.rz-frozen-cell,
 .rz-grid-table-striped tbody > tr:nth-child(odd) > td.rz-frozen-cell {
     background-color: var(--inn-grid-row-odd-background-color);
 }
 
+.rz-grid-table tbody > tr:nth-child(even) > td.rz-frozen-cell,
 .rz-grid-table-striped tbody > tr:nth-child(even) > td.rz-frozen-cell {
     background-color: var(--inn-grid-row-even-background-color);
 }

--- a/Src/Innovative.Blazor.Components/Components/Grid/InnovativeGrid.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Grid/InnovativeGrid.razor.css
@@ -57,11 +57,11 @@
 }
 
 /* Table body */
-::deep .rz-grid-table tbody > tr:nth-child(2n+1) > td {
+::deep .rz-grid-table tbody > tr:not(.rz-expanded-row-content):nth-child(2n+1) > td {
     background-color: var(--inn-grid-row-odd-background-color);
 }
 
-::deep .rz-grid-table tbody > tr:nth-child(2n) > td {
+::deep .rz-grid-table tbody > tr:not(.rz-expanded-row-content):nth-child(2n) > td {
     background-color: var(--inn-grid-row-even-background-color);
 }
 

--- a/Src/Innovative.Blazor.Components/Components/Grid/InnovativeGrid.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Grid/InnovativeGrid.razor.css
@@ -57,11 +57,13 @@
 }
 
 /* Table body */
-::deep .rz-grid-table tbody > tr:not(.rz-expanded-row-content):nth-child(2n+1) > td {
+::deep .rz-grid-table tbody > tr:not(.rz-expanded-row-content):nth-child(2n+1) > td,
+::deep .rz-grid-table-striped tbody > tr:not(.rz-expanded-row-content):nth-child(2n+1) > td {
     background-color: var(--inn-grid-row-odd-background-color);
 }
 
-::deep .rz-grid-table tbody > tr:not(.rz-expanded-row-content):nth-child(2n) > td {
+::deep .rz-grid-table tbody > tr:not(.rz-expanded-row-content):nth-child(2n) > td,
+::deep .rz-grid-table-striped tbody > tr:not(.rz-expanded-row-content):nth-child(2n) > td {
     background-color: var(--inn-grid-row-even-background-color);
 }
 


### PR DESCRIPTION
Met deze css variabelen kan ik makkelijker kleuren aanpassen in de Automate website.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style Improvements**
  * Grid tables now display alternating row backgrounds (zebra striping) for better readability.
  * Improved visual indicators for focused and selected grid rows, including distinct background, text, and border styles.
  * Enhanced header and frozen-column styling for clearer visual separation.
  * Exposed new theme variables to customize selected/focus backgrounds, text color, and focus border color.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->