### PR TITLE
273 Het woord "text" in de CSS variabelen verwijderen

### DIFF
--- a/ExampleApp/wwwroot/css/app.css
+++ b/ExampleApp/wwwroot/css/app.css
@@ -91,21 +91,21 @@
 
     /* Component Colors */
     /* Button */
-    --inn-button-base-text-color: var(--inn-gray-900);
+    --inn-button-base-color: var(--inn-gray-900);
     --inn-button-base-background-color: var(--inn-gray-100);
     --inn-button-base-hover-color: var(--inn-gray-900);
     --inn-button-base-hover-background-color: var(--inn-gray-200);
-    --inn-button-primary-text-color: var(--inn-gray-50);
+    --inn-button-primary-color: var(--inn-gray-50);
     --inn-button-primary-background-color: var(--inn-primary);
-    --inn-button-primary-hover-text-color: var(--inn-gray-50);
+    --inn-button-primary-hover-color: var(--inn-gray-50);
     --inn-button-primary-hover-background-color: var(--inn-primary-dark);
-    --inn-button-secondary-text-color: var(--inn-gray-50);
+    --inn-button-secondary-color: var(--inn-gray-50);
     --inn-button-secondary-background-color: var(--inn-secondary);
-    --inn-button-secondary-hover-text-color: var(--inn-gray-50);
+    --inn-button-secondary-hover-color: var(--inn-gray-50);
     --inn-button-secondary-hover-background-color: var(--inn-secondary-dark);
-    --inn-button-danger-text-color: var(--inn-danger-darker);
+    --inn-button-danger-color: var(--inn-danger-darker);
     --inn-button-danger-background-color: var(--inn-danger-lighter);
-    --inn-button-danger-hover-text-color: var(--inn-danger-darker);
+    --inn-button-danger-hover-color: var(--inn-danger-darker);
     --inn-button-danger-hover-background-color: var(--inn-danger-light);
 
     /* Input */
@@ -185,27 +185,27 @@
 
     /* Alert */
     --inn-alert-danger-icon-color: var(--inn-danger);
-    --inn-alert-danger-text-color: var(--inn-gray-900);
+    --inn-alert-danger-color: var(--inn-gray-900);
     --inn-alert-danger-background-color: var(--inn-danger-lighter);
-    --inn-alert-danger-close-text-color: var(--inn-gray-900);
+    --inn-alert-danger-close-color: var(--inn-gray-900);
     --inn-alert-danger-close-background-color: var(--inn-danger-light);
     --inn-alert-danger-close-hover-background-color: var(--inn-gray-200);
     --inn-alert-success-icon-color: var(--inn-success);
-    --inn-alert-success-text-color: var(--inn-gray-900);
+    --inn-alert-success-color: var(--inn-gray-900);
     --inn-alert-success-background-color: var(--inn-success-lighter);
-    --inn-alert-success-close-text-color: var(--inn-gray-900);
+    --inn-alert-success-close-color: var(--inn-gray-900);
     --inn-alert-success-close-background-color: var(--inn-success-light);
     --inn-alert-success-close-hover-background-color: var(--inn-gray-200);
     --inn-alert-warning-icon-color: var(--inn-warning);
-    --inn-alert-warning-text-color: var(--inn-gray-900);
+    --inn-alert-warning-color: var(--inn-gray-900);
     --inn-alert-warning-background-color: var(--inn-warning-lighter);
-    --inn-alert-warning-close-text-color: var(--inn-gray-900);
+    --inn-alert-warning-close-color: var(--inn-gray-900);
     --inn-alert-warning-close-background-color: var(--inn-warning-light);
     --inn-alert-warning-close-hover-background-color: var(--inn-gray-200);
     --inn-alert-info-icon-color: var(--inn-info);
-    --inn-alert-info-text-color: var(--inn-gray-900);
+    --inn-alert-info-color: var(--inn-gray-900);
     --inn-alert-info-background-color: var(--inn-info-lighter);
-    --inn-alert-info-close-text-color: var(--inn-gray-900);
+    --inn-alert-info-close-color: var(--inn-gray-900);
     --inn-alert-info-close-background-color: var(--inn-info-light);
     --inn-alert-info-close-hover-background-color: var(--inn-gray-200);
 

--- a/Src/Innovative.Blazor.Components/Components/Alert/InnovativeAlert.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/Alert/InnovativeAlert.razor.css
@@ -19,17 +19,17 @@
 }
 
 .innovative-alert-error {
-    color: var(--inn-alert-danger-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-danger-color, var(--inn-gray-900));
     background: var(--inn-alert-danger-background-color, var(--inn-danger-lighter));
 }
 
 .innovative-alert-error .innovative-alert-close {
-    color: var(--inn-alert-danger-close-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-danger-close-color, var(--inn-gray-900));
     background: var(--inn-alert-danger-close-background-color, var(--inn-danger-light));
 }
 
 .innovative-alert-error .innovative-alert-close:hover {
-    color: var(--inn-alert-danger-close-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-danger-close-color, var(--inn-gray-900));
     background: var(--inn-alert-danger-close-hover-background-color, var(--inn-gray-200));
 }
 
@@ -39,17 +39,17 @@
 }
 
 .innovative-alert-success {
-    color: var(--inn-alert-success-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-success-color, var(--inn-gray-900));
     background: var(--inn-alert-success-background-color, var(--inn-success-lighter));
 }
 
 .innovative-alert-success .innovative-alert-close {
-    color: var(--inn-alert-success-close-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-success-close-color, var(--inn-gray-900));
     background: var(--inn-alert-success-close-background-color, var(--inn-success-light));
 }
 
 .innovative-alert-success .innovative-alert-close:hover {
-    color: var(--inn-alert-success-close-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-success-close-color, var(--inn-gray-900));
     background: var(--inn-alert-success-close-hover-background-color, var(--inn-gray-200));
 }
 
@@ -59,17 +59,17 @@
 }
 
 .innovative-alert-warning {
-    color: var(--inn-alert-warning-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-warning-color, var(--inn-gray-900));
     background: var(--inn-alert-warning-background-color, var(--inn-warning-lighter));
 }
 
 .innovative-alert-warning .innovative-alert-close {
-    color: var(--inn-alert-warning-close-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-warning-close-color, var(--inn-gray-900));
     background: var(--inn-alert-warning-close-background-color, var(--inn-warning-light));
 }
 
 .innovative-alert-warning .innovative-alert-close:hover {
-    color: var(--inn-alert-warning-close-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-warning-close-color, var(--inn-gray-900));
     background: var(--inn-alert-warning-close-hover-background-color, var(--inn-gray-200));
 }
 
@@ -79,17 +79,17 @@
 }
 
 .innovative-alert-info {
-    color: var(--inn-alert-info-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-info-color, var(--inn-gray-900));
     background: var(--inn-alert-info-background-color, var(--inn-info-lighter));
 }
 
 .innovative-alert-info .innovative-alert-close {
-    color: var(--inn-alert-info-close-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-info-close-color, var(--inn-gray-900));
     background: var(--inn-alert-info-close-background-color, var(--inn-info-light));
 }
 
 .innovative-alert-info .innovative-alert-close:hover {
-    color: var(--inn-alert-info-close-text-color, var(--inn-gray-900));
+    color: var(--inn-alert-info-close-color, var(--inn-gray-900));
     background: var(--inn-alert-info-close-hover-background-color, var(--inn-gray-200));
 }
 

--- a/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.css
+++ b/Src/Innovative.Blazor.Components/Components/SidePanel/SidePanelComponent.razor.css
@@ -62,12 +62,12 @@
 }
 
 .sidepanel-icon-button .material-symbols-outlined {
-    color: var(--inn-button-base-text-color);
+    color: var(--inn-button-base-color);
     font-size: var(--inn-icon-font-size);
 }
 
 .sidepanel-icon-button:hover  .material-symbols-outlined {
-    color: var(--inn-button-base-text-color);
+    color: var(--inn-button-base-color);
 }
 
 .sidepanel-actions ::deep .sidepanel-icon-button .rz-button-box .material-symbols-outlined,
@@ -77,7 +77,7 @@
 
 /* Primary button */
 ::deep .rz-button.rz-primary.rz-shade-default {
-    color: var(--inn-button-primary-text-color, var(--inn-gray-50));
+    color: var(--inn-button-primary-color, var(--inn-gray-50));
     background-color: var(--inn-button-primary-background-color, var(--inn-primary));
     box-shadow: var(--inn-button-shadow);
 }
@@ -94,16 +94,16 @@
     outline-offset: var(--inn-focus-outline-offset);
 }
 ::deep .rz-button.rz-primary.rz-shade-default .material-symbols-outlined {
-    color: var(--inn-button-primary-text-color, var(--inn-gray-50));
+    color: var(--inn-button-primary-color, var(--inn-gray-50));
     font-size: var(--inn-icon-font-size);
 }
 ::deep .rz-button.rz-primary.rz-shade-default:hover .material-symbols-outlined {
-    color: var(--inn-button-primary-hover-text-color, var(--inn-gray-50));
+    color: var(--inn-button-primary-hover-color, var(--inn-gray-50));
 }
 
 /* Secondary button */
 ::deep .rz-button.rz-secondary.rz-shade-default {
-    color: var(--inn-button-secondary-text-color, var(--inn-gray-50));
+    color: var(--inn-button-secondary-color, var(--inn-gray-50));
     background-color: var(--inn-button-secondary-background-color, var(--inn-secondary));
     box-shadow: var(--inn-button-shadow);
 }
@@ -120,17 +120,17 @@
     outline-offset: var(--inn-focus-outline-offset);
 }
 ::deep .rz-button.rz-secondary.rz-shade-default .material-symbols-outlined {
-    color: var(--inn-button-secondary-text-color, var(--inn-gray-50));
+    color: var(--inn-button-secondary-color, var(--inn-gray-50));
     font-size: var(--inn-icon-font-size);
 }
 ::deep .rz-button.rz-secondary.rz-shade-default:hover .material-symbols-outlined {
-    color: var(--inn-button-secondary-hover-text-color, var(--inn-gray-50));
+    color: var(--inn-button-secondary-hover-color, var(--inn-gray-50));
 }
 
 /* Danger button */
 ::deep .rz-button.rz-danger.rz-shade-default {
     background-color: var(--inn-button-danger-background-color, var(--inn-danger-lighter));
-    color: var(--inn-button-danger-text-color, var(--inn-danger-darker));
+    color: var(--inn-button-danger-color, var(--inn-danger-darker));
     box-shadow: var(--inn-button-shadow);
 }
 ::deep .rz-button.rz-danger.rz-shade-default:hover {
@@ -147,11 +147,11 @@
     outline-offset: var(--inn-focus-outline-offset);
 }
 ::deep .rz-button.rz-danger.rz-shade-default .material-symbols-outlined {
-    color: var(--inn-button-danger-text-color, var(--inn-danger-darker));
+    color: var(--inn-button-danger-color, var(--inn-danger-darker));
     font-size: var(--inn-icon-font-size);
 }
 ::deep .rz-button.rz-danger.rz-shade-default:hover .material-symbols-outlined {
-    color: var(--inn-button-danger-hover-text-color, var(--inn-danger-darker));
+    color: var(--inn-button-danger-hover-color, var(--inn-danger-darker));
 }
 
 ::deep .rz-pager-element,


### PR DESCRIPTION
Het woord `text` is verwijderd uit CSS variabelen om de naamgeving korter, consistenter en beter leesbaar te maken. Uitzondering hierop zijn de text color variabelen en text-transform. Deze behouden bewust het woord text, omdat het daar de semantiek en duidelijkheid van de variabelen verbetert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated styling system naming conventions across button and alert components to improve internal consistency and maintainability. No changes to visual appearance or functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->